### PR TITLE
v0.3 spec finalize: pat table DDL, identity.md PAT chapter, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable spec changes are recorded here. Adopter-facing migration guidance lives in [`docs/migrating-to-v0.2.md`](docs/migrating-to-v0.2.md). Per-SDK changelogs live in their respective repos; this file tracks the spec contract only.
 
+## [v0.3.0] — Unreleased (in development)
+
+### Added
+- **ADR 0016** — Personal access tokens. New `pat_` primitive for non-interactive (CLI / CI / server-to-server) auth. Wire format `pat_<32hex-id>_<base64url-secret>` (Stripe-style id-then-secret); the auth middleware prefix-routes incoming bearer tokens to session / share / PAT verifiers. Argon2id storage at the cred-password parameter floor; conflated `InvalidPatTokenError` shape on missing-row vs wrong-secret to avoid a token-presence timing oracle. New `auth.kind ∈ {session, pat, share, system}` audit discriminator (additive). Closes [`spec#14`](https://github.com/flametrench/spec/issues/14).
+- **OpenAPI v0.3 additions** (`openapi/flametrench-v0.3-additions.yaml`) — four PAT management routes: `POST /v1/users/{usr_id}/pats`, `GET /v1/users/{usr_id}/pats`, `GET /v1/pats/{pat_id}`, `POST /v1/pats/{pat_id}/revoke`. Verification stays SDK-only (no public `/pats/verify`), mirroring the share-token precedent.
+- **Reference Postgres** — new `pat` table with Argon2id `secret_hash`, `usr_id` FK, `name`, `scope TEXT[]`, `expires_at`, `last_used_at`, `revoked_at`, plus three indexes (per-user list, active filter, expiry sweep) and a `pat_touch` trigger. Lookup is by primary key (id), not token hash — contrast with `ses` and `shr`, whose wire formats are opaque.
+- **`identity.md` chapter** — Personal access tokens (v0.3): wire format, bearer routing, normative verification semantics (8-step ordering), lifecycle, operations, `auth.kind` discriminator, cross-SDK parity contract.
+
+### SDK matrix
+- v0.3.0 SDK ports begin with PHP and Node (the unblocked registries). Python and Java implementations land code-ready and tagged but unpublished, pending the same registry blockers that held v0.2.0 (PyPI org approval, Maven Central credential regen).
+
 ## [v0.2.0] — 2026-04-30
 
 v0.2.0 stable cutoff. No surface changes vs `v0.2.0-rc.6`; this release flips ADRs 0007–0015 from Proposed to Accepted, snaps the four SDK families to `v0.2.0` (Python / Node / PHP / Java for `ids` / `identity` / `tenancy` / `authz`), and bumps the OpenAPI overlay version field from `0.2.0-rc.6` to `0.2.0`.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ What this specification does not define:
 
 - **v0.1 spec**: shipped. Adopted by sitesource/admin (the first PHP adopter); spec#5 surfaced in adoption and was patched in v0.1.x via ADR 0009.
 - **v0.2 spec**: stable, tagged `v0.2.0`. Surface: rewrite rules (ADR 0007), MFA TOTP/WebAuthn/recovery (ADRs 0008 + 0010), invitation acceptance binding (ADR 0009, also in v0.1.x), org display name + slug (ADR 0011), share tokens (ADR 0012), Postgres adapter transaction nesting (ADR 0013), user display name (ADR 0014), and user enumeration (ADR 0015).
+- **v0.3 spec**: in development. Surface: personal access tokens (ADR 0016) — non-interactive bearer credentials for CLI / CI / server-to-server use, with prefix-routed verification (`pat_…` / `shr_…` / session) and a new `auth.kind` audit discriminator. Targets PHP + Node first (the unblocked registries); Python + Java land code-ready and tagged in lockstep, awaiting registry unblock for publication.
 - **SDKs**: Python / Node / PHP / Java span `v0.2.0`–`v0.2.1` across the family (`ids`, `identity`, `tenancy`, `authz`). Packagist and npm publish the live artifacts; PyPI and Maven Central are bootstrapping (org / credential approvals pending) and will publish once unblocked. Always verify a registry directly before quoting state: `npm view @flametrench/<pkg> versions --json` (note the plural — singular `version` returns only the `latest` dist-tag). The release checklist at `docs/release-checklist.md` is the canonical pre-publish process.
-- **Postgres reference**: `postgres.sql` covers the full v0.1 + v0.2 data model (including the `mfa`, `usr_mfa_policy`, and `shr` tables added in v0.2; `usr.display_name` column also added in v0.2). `postgres-rls.sql` is an optional RLS companion.
-- **Conformance suite**: 27 fixture files, executed by all four SDK families.
+- **Postgres reference**: `postgres.sql` covers the full v0.1 + v0.2 + v0.3-in-development data model (including the `mfa`, `usr_mfa_policy`, and `shr` tables added in v0.2, the `pat` table added in v0.3, and the `usr.display_name` column added in v0.2). `postgres-rls.sql` is an optional RLS companion.
+- **Conformance suite**: 27 fixture files, executed by all four SDK families. v0.3 PAT fixtures land alongside the SDK ports.
 
 ## Structure of this repository
 
@@ -114,7 +115,7 @@ flametrench/spec/
 │   ├── security.md              threat model + adopter responsibilities (normative)
 │   ├── external-idps.md         coexistence with Auth0 / Clerk / Cognito / etc. (non-normative)
 │   └── migrating-to-v0.2.md     upgrade guide for v0.1 adopters
-├── decisions/                   Architecture Decision Records (15 ADRs)
+├── decisions/                   Architecture Decision Records (16 ADRs)
 │   ├── README.md                index + ADR writing guide
 │   ├── 0001 — authorization model
 │   ├── 0002 — tenancy model
@@ -130,14 +131,16 @@ flametrench/spec/
 │   ├── 0012 — share tokens                                 (v0.2)
 │   ├── 0013 — Postgres adapter transaction nesting          (v0.2)
 │   ├── 0014 — user display name                             (v0.2)
-│   └── 0015 — IdentityStore.listUsers                       (v0.2)
+│   ├── 0015 — IdentityStore.listUsers                       (v0.2)
+│   └── 0016 — personal access tokens                         (v0.3)
 ├── reference/                   non-normative implementation artifacts
 │   ├── README.md                conventions; what's normative vs reference
-│   ├── postgres.sql             reference Postgres DDL (v0.1 + v0.2 additive)
+│   ├── postgres.sql             reference Postgres DDL (v0.1 + v0.2 + v0.3 additive)
 │   └── postgres-rls.sql         optional Row-Level Security companion
 ├── openapi/
-│   ├── flametrench-v0.1.yaml    v0.1 wire surface (ADR 0009 patch included)
-│   └── flametrench-v0.2-additions.yaml   MFA additive overlay
+│   ├── flametrench-v0.1.yaml              v0.1 wire surface (ADR 0009 patch included)
+│   ├── flametrench-v0.2-additions.yaml    v0.2 additive overlay (MFA, display names, listUsers)
+│   └── flametrench-v0.3-additions.yaml    v0.3 additive overlay (personal access tokens)
 ├── conformance/
 │   ├── index.json               27-fixture manifest
 │   ├── fixture.schema.json

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -416,6 +416,89 @@ A `fixtures/identity/mfa/` corpus will land alongside the v0.2 SDK ports, anchor
 
 See [ADR 0008](../decisions/0008-mfa.md) for the full design rationale, alternatives considered, and explicit deferrals.
 
+## Personal access tokens (v0.3)
+
+A personal access token (PAT) is a long-lived bearer credential bound to a `usr_id`, intended for non-interactive use — CLI tools, CI pipelines, server-to-server calls. PATs are a separate primitive from credentials and from sessions. They have a different lifecycle (no rotation, no `replaces` chain), a different verification path (the token IS the proof; no interactive challenge), and a different audit shape (`auth.kind = 'pat'`).
+
+### Wire format
+
+The full bearer token is `pat_<32hex-id>_<base64url-secret>`:
+
+  - `pat_` — the type prefix used for routing (see *Bearer routing* below).
+  - `<32hex-id>` — the wire-format encoding of the PAT row's primary key. Indexed; the lookup handle.
+  - `_<base64url-secret>` — the secret half. ≥256 bits of entropy, RFC 4648 §5 base64url with no padding. Verified by Argon2id against the stored hash.
+
+The plaintext token is returned ONCE in the `createPat` response and never again. The server stores only an Argon2id hash of the secret segment (parameters at the spec floor pinned for cred passwords by ADR 0004).
+
+### Bearer routing
+
+v0.3 broadens what the `Authorization: Bearer` header may carry. The auth middleware MUST inspect the token prefix and dispatch to the matching verifier:
+
+  - `pat_<32hex>_<…>` → `verifyPatToken` (this section)
+  - `shr_<32hex>_<…>` → `verifyShareToken` (ADR 0012)
+  - any other prefix → session resolver (v0.1)
+
+Mis-routing is a 401 with `code: auth.token_format_unrecognized`. Verifiers MUST NOT attempt cross-form decoding (e.g. trying a `pat_…` string against the session resolver) — bearer types do not overlap by design, and silent fallbacks would mask legitimate token-format errors.
+
+The `@flametrench/server` package ships a `resolveBearer(token, { sessionStore, patStore, shareStore })` helper that implements this dispatch; PHP / Python / Java equivalents follow the same signature.
+
+### Verification semantics
+
+Normative ordering for `verifyPatToken`:
+
+  1. Inspect the prefix; reject non-`pat_…` tokens with `auth.token_format_unrecognized`.
+  2. Split on the first underscore after `pat_<32hex>` to recover the id segment and the secret segment.
+  3. Look up the row by id (`SELECT … WHERE id = $id`).
+  4. If the row is missing, return `InvalidPatTokenError`. The error message MUST conflate "no such row" with "wrong secret" to avoid a token-presence timing oracle.
+  5. If `revoked_at IS NOT NULL`, return `PatRevokedError`.
+  6. If `expires_at IS NOT NULL` and `expires_at <= now()`, return `PatExpiredError`.
+  7. Argon2id-verify the secret segment against `secret_hash`. Mismatch returns `InvalidPatTokenError` (same shape as step 4).
+  8. Update `last_used_at`. The SDK MAY coalesce these writes within a configurable window (60s default) to avoid a write-per-request hot path.
+
+The error ordering — revoked > expired > invalid_secret — matches the share-token convention from ADR 0012.
+
+### Lifecycle
+
+A PAT row is one of three states:
+
+  - `active` — present, not expired, not revoked.
+  - `expired` — past `expires_at`. Terminal: a PAT cannot return to active.
+  - `revoked` — `revokePat` was called. Terminal: re-issuance creates a new row, NOT a `replaces` chain entry. (Cred lineage tracking is for interactive credentials where the user is rotating an identifier; PATs are bearer secrets with no identity continuity to preserve.)
+
+Revoke is idempotent: revoking an already-revoked token returns the existing row.
+
+### Operations
+
+  - `createPat({ usr_id, name, scope, expires_at? })` → `{ pat, token }`. The `token` is the plaintext; the caller MUST capture it immediately. `name` is a human label (≤120 chars); `scope` is an application-defined `string[]`; `expires_at` is optional (no expiry when omitted).
+  - `getPat(pat_id)` → `PersonalAccessToken`. Metadata only — secret hash never serialized.
+  - `listPatsForUser(usr_id, *, cursor, limit, status?)` → `Page<PersonalAccessToken>`. Cursor-paginated, mirrors `listMembers` shape. Default returns all statuses; pass `status='active'` to filter.
+  - `revokePat(pat_id)` → `PersonalAccessToken`. Terminal-state transition; idempotent.
+  - `verifyPatToken(token)` → `VerifiedPat { pat_id, usr_id, scope, prefix }`. Throws `InvalidPatTokenError` / `PatExpiredError` / `PatRevokedError` per the ordering above.
+
+Authorization gating is the adopter's responsibility — typically "the requesting principal owns `usr_id`, OR is a sysadmin acting on the user's behalf." The SDK does not enforce visibility on `getPat` / `listPatsForUser` / `revokePat`.
+
+### `auth.kind` audit discriminator
+
+Adopters that emit audit-log records SHOULD populate an `auth.kind` field with one of:
+
+  - `session` — interactive bearer minted via `verifyPassword` (+ optional `verifyMfa`).
+  - `pat` — bearer resolved by `verifyPatToken`.
+  - `share` — bearer resolved by `verifyShareToken` (ADR 0012).
+  - `system` — operator-initiated action with no human bearer (cron, sysadmin script).
+
+The field is additive: pre-v0.3 audit records that omit `auth.kind` remain valid. Adopters that track auditable mutation paths SHOULD start populating it before issuing PATs in production, so an attacker abusing a leaked PAT can be distinguished in the audit trail from one abusing a hijacked session.
+
+### Cross-SDK parity contract
+
+A `fixtures/identity/pat/` corpus lands alongside the v0.3 SDK ports, anchored on:
+
+  - Issuance: `createPat` returns a token of the documented wire format; `secret_hash` is Argon2id at floor parameters; `name` and `scope` round-trip.
+  - Verify: each error class (`InvalidPatTokenError` for missing row, `InvalidPatTokenError` for wrong secret, `PatExpiredError` for past `expires_at`, `PatRevokedError` for terminal) fires under the right conditions, in the right ordering.
+  - Revoke: idempotent; revoked tokens fail `verifyPatToken` with `PatRevokedError` thereafter.
+  - Audit: `auth.kind = 'pat'` shape matches across SDKs.
+
+See [ADR 0016](../decisions/0016-personal-access-tokens.md) for the full design rationale, alternatives considered, and explicit deferrals.
+
 ## Conformance fixtures
 
 The following fixtures are REQUIRED for identity interoperability across conforming implementations:

--- a/reference/postgres.sql
+++ b/reference/postgres.sql
@@ -688,6 +688,89 @@ CREATE INDEX shr_expires_idx ON shr (expires_at)
     WHERE revoked_at IS NULL;
 
 -- ===========================================================================
+-- v0.3 additions: personal access tokens per ADR 0016 (Proposed)
+-- ===========================================================================
+--
+-- A PAT is a long-lived bearer credential bound to a `usr_id`, intended
+-- for non-interactive use (CLI / CI / server-to-server). The wire token
+-- is `pat_<32hex-id>_<base64url-secret>`: the id half is the indexed
+-- handle (this row's primary key), the secret half is verified by
+-- Argon2id against `secret_hash`. The plaintext token is returned ONCE
+-- on createPat and never persisted.
+--
+-- PATs are NOT a cred variant. They have a different lifecycle (no
+-- rotation, no replaces chain), a different verification path (bearer
+-- secret, not interactive credential), and a different audit shape
+-- (`auth.kind = 'pat'`). They are stored separately to keep these
+-- semantics distinct from the cred model.
+--
+-- Verification protocol (normative; see ADR 0016 §"Verification semantics"):
+--
+--   1. The auth middleware inspects the bearer prefix. `pat_…` routes
+--      to verifyPatToken; other prefixes route to session / share
+--      verifiers respectively.
+--   2. Split the token on the FIRST underscore after `pat_<32hex>` to
+--      recover the id segment and the secret segment.
+--   3. SELECT … FROM pat WHERE id = $id_decoded.
+--   4. If the row is missing, return InvalidPatTokenError. The error
+--      message MUST conflate "no such row" with "wrong secret" to
+--      avoid a token-presence timing oracle.
+--   5. If revoked_at IS NOT NULL, return PatRevokedError.
+--   6. If expires_at IS NOT NULL AND expires_at <= now(), return
+--      PatExpiredError.
+--   7. Argon2id-verify the secret segment against secret_hash.
+--      Mismatch → InvalidPatTokenError (same shape as step 4).
+--   8. Update last_used_at. The SDK MAY coalesce these writes within
+--      a configurable window (60s default) to avoid a write-per-
+--      request hot path.
+--
+-- The error ordering (revoked > expired > invalid_secret) matches the
+-- share-token convention from ADR 0012.
+
+CREATE TABLE pat (
+    id            UUID PRIMARY KEY,
+    usr_id        UUID NOT NULL REFERENCES usr(id),
+    name          TEXT NOT NULL,
+
+    -- Application-defined scope claims. The spec does not pin
+    -- vocabulary; adopters' authz layer interprets the strings.
+    scope         TEXT[] NOT NULL DEFAULT '{}',
+
+    -- PHC-encoded Argon2id hash of the base64url secret segment.
+    -- Spec pins the same minimum parameters as cred.password_hash:
+    -- memory >= 19 MiB, iterations >= 2, parallelism >= 1 (OWASP floor).
+    -- The plaintext secret leaves the server exactly once (createPat).
+    secret_hash   TEXT NOT NULL,
+
+    expires_at    TIMESTAMPTZ,
+    last_used_at  TIMESTAMPTZ,
+    revoked_at    TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CHECK (expires_at   IS NULL OR expires_at   > created_at),
+    CHECK (last_used_at IS NULL OR last_used_at >= created_at),
+    CHECK (revoked_at   IS NULL OR revoked_at   >= created_at),
+    -- `name` is a human label shown in the user's token list. Adopters
+    -- MAY enforce a tighter cap; 120 is the spec ceiling.
+    CHECK (length(name) BETWEEN 1 AND 120)
+);
+
+-- "List PATs for this user" — primary enumeration path.
+CREATE INDEX pat_usr_idx ON pat (usr_id, created_at DESC);
+
+-- "Active PATs only" — speeds up status='active' filter on the list path.
+CREATE INDEX pat_usr_active_idx ON pat (usr_id, created_at DESC)
+    WHERE revoked_at IS NULL;
+
+-- "Sweep expired PATs" — operational cleanup; not on the verify hot
+-- path. The verify path looks up by primary key (id), so no token-hash
+-- index is needed (contrast with `ses` and `shr`, which look up by
+-- token hash because their wire format is opaque).
+CREATE INDEX pat_expires_idx ON pat (expires_at)
+    WHERE revoked_at IS NULL AND expires_at IS NOT NULL;
+
+-- ===========================================================================
 -- v0.2 note: rewrite rules (ADR 0007)
 -- ===========================================================================
 --
@@ -727,6 +810,10 @@ CREATE TRIGGER mem_touch  BEFORE UPDATE ON mem
 CREATE TRIGGER mfa_touch              BEFORE UPDATE ON mfa
     FOR EACH ROW EXECUTE FUNCTION flametrench_touch_updated_at();
 CREATE TRIGGER usr_mfa_policy_touch   BEFORE UPDATE ON usr_mfa_policy
+    FOR EACH ROW EXECUTE FUNCTION flametrench_touch_updated_at();
+
+-- v0.3:
+CREATE TRIGGER pat_touch              BEFORE UPDATE ON pat
     FOR EACH ROW EXECUTE FUNCTION flametrench_touch_updated_at();
 
 -- ses, inv, and tup are append-only / lifecycle-terminal; no updated_at.


### PR DESCRIPTION
Phase A of the v0.3 ship plan. ADR 0016 (#15) and the OpenAPI v0.3 additions (#16) are already on main; this PR lands the remaining spec-level wire shapes so SDK ports have a fixed target.

## Summary
- \`reference/postgres.sql\` — new \`pat\` table (Argon2id \`secret_hash\` PHC-encoded, \`scope TEXT[]\`, three indexes, \`pat_touch\` trigger). Lookup is by primary key — no token-hash index, contrast with \`ses\`/\`shr\`.
- \`docs/identity.md\` — new "Personal access tokens (v0.3)" chapter: wire format, bearer routing, 8-step normative verification ordering, lifecycle, operations, \`auth.kind\` discriminator, cross-SDK parity contract.
- \`CHANGELOG.md\` — \`v0.3.0\` Unreleased entry.
- \`README.md\` — Status gains a v0.3-in-development bullet; structure tree gains ADR 0016, the v0.3 OpenAPI overlay, and the v0.3 \`pat\` table label.

## Why this lands as one PR
All four files describe the same primitive's wire shape. SDK ports are blocked on the contract being fixed; merging them as one diff lets PHP and Node start in parallel against a stable target.

## Test plan
- [ ] Apply \`postgres.sql\` to a fresh DB; confirm \`pat\` table + trigger create cleanly.
- [ ] Skim the identity.md chapter end-to-end as the source of truth for SDK ports.
- [ ] Confirm no broken cross-references in README structure tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)