### PR TITLE
ADR 0017: Postgres rewrite-rule evaluation (v0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ All notable spec changes are recorded here. Adopter-facing migration guidance li
 - **OpenAPI v0.3 additions** (`openapi/flametrench-v0.3-additions.yaml`) — four PAT management routes: `POST /v1/users/{usr_id}/pats`, `GET /v1/users/{usr_id}/pats`, `GET /v1/pats/{pat_id}`, `POST /v1/pats/{pat_id}/revoke`. Verification stays SDK-only (no public `/pats/verify`), mirroring the share-token precedent.
 - **Reference Postgres** — new `pat` table with Argon2id `secret_hash`, `usr_id` FK, `name`, `scope TEXT[]`, `expires_at`, `last_used_at`, `revoked_at`, plus three indexes (per-user list, active filter, expiry sweep) and a `pat_touch` trigger. Lookup is by primary key (id), not token hash — contrast with `ses` and `shr`, whose wire formats are opaque.
 - **`identity.md` chapter** — Personal access tokens (v0.3): wire format, bearer routing, normative verification semantics (8-step ordering), lifecycle, operations, `auth.kind` discriminator, cross-SDK parity contract.
+- **ADR 0017** — Postgres rewrite-rule evaluation. Retires the v0.2 deferral in `docs/authorization.md`. `PostgresTupleStore.check()` now accepts the same `rules` option as `InMemoryTupleStore` and evaluates via iterative async expansion (one indexed SELECT per direct lookup / `tuple_to_userset` enumeration, recursive over `computed_userset`). Cycle detection, depth + fan-out bounds, and short-circuit semantics from ADR 0007 are unchanged. SQL push-down via recursive CTEs explicitly rejected for v0.3 — round-trip count isn't the bottleneck on properly-indexed `tup` tables. Revisit in v0.4+ as an opt-in escape hatch.
+- **Node-only API change** — `evaluate()` (the internal rewrite-rule evaluator) becomes async-capable: `DirectLookup` and `ListByObject` callbacks return `Promise<...>`. `InMemoryTupleStore` wraps in `Promise.resolve(...)`; `PostgresTupleStore` issues real async queries. PHP/Python/Java keep synchronous callbacks (no language async coroutine bridge in v0.3).
 
 ### SDK matrix
 - v0.3.0 SDK ports begin with PHP and Node (the unblocked registries). Python and Java implementations land code-ready and tagged but unpublished, pending the same registry blockers that held v0.2.0 (PyPI org approval, Maven Central credential regen).
+- Both v0.3 features (PATs + Postgres rewrite-rules) ship together in each SDK release.
 
 ## [v0.2.0] — 2026-04-30
 

--- a/decisions/0017-postgres-rewrite-rule-evaluation.md
+++ b/decisions/0017-postgres-rewrite-rule-evaluation.md
@@ -1,0 +1,129 @@
+# 0017. Postgres rewrite-rule evaluation
+
+Status: Proposed (v0.3 — in development)
+
+Date: 2026-05-01
+
+## Context
+
+ADR 0007 specified the v0.2 rewrite-rule language and a three-step evaluation algorithm: direct lookup → rule expansion → short-circuit on first match. All four SDK families shipped that algorithm in v0.2 via their `InMemoryTupleStore`. The reference document `docs/authorization.md` then explicitly deferred Postgres-backed rule evaluation to v0.3:
+
+> Postgres-backed rule evaluation is deferred to v0.3 — adopters who need Postgres durability today can keep the rules-relevant tuple subset in-memory and use the in-memory `check()` for those queries.
+
+`PostgresTupleStore.check()` in v0.2 is exact-match-only: a single SELECT against the natural key with no rule expansion. Adopters whose tuples live in Postgres but who want rule-based authorization have, until v0.3, had to load the relevant tuple subset into an `InMemoryTupleStore` at request time. That works for small graphs but is operationally awkward — it forces a parallel data path, doubles the memory footprint, and breaks down once the tuple set is too large to materialize.
+
+This ADR retires the deferral. It pins the implementation strategy that `PostgresTupleStore` (across all four SDK families) MUST follow when evaluating rewrite rules, and the corresponding SDK-internal API change that lets the rule evaluator drive async tuple lookups against a database.
+
+## Decision
+
+### Iterative async expansion, not SQL push-down
+
+`PostgresTupleStore.check()` evaluates rewrite rules using the same algorithm specified in ADR 0007 (direct lookup, recursive expansion, union short-circuit, cycle detection, depth + fan-out bounds). The difference vs. `InMemoryTupleStore` is that each tuple lookup is a single async SELECT against Postgres rather than a synchronous map probe.
+
+A worked example. For the rule `proj.viewer = this | computed_userset(editor) | tuple_to_userset(parent_org → org.viewer)` and a check `(usr_a, viewer, proj_x)`:
+
+1. Direct lookup: `SELECT id FROM tup WHERE subject_type = 'usr' AND subject_id = $usr_a AND relation = 'viewer' AND object_type = 'proj' AND object_id = $proj_x LIMIT 1`. One round trip. Hit ⇒ return.
+2. Miss ⇒ rule expansion. `computed_userset(editor)` recurses into `(usr_a, editor, proj_x)` — the same shape against the same table.
+3. `tuple_to_userset(parent_org → org.viewer)` runs `SELECT subject_type, subject_id FROM tup WHERE object_type = 'proj' AND object_id = $proj_x AND relation = 'parent_org'`, then for each result recurses into `(usr_a, viewer, $resulting_org)`.
+
+Total cost is bounded by the rule's static depth and the per-step fan-out bound. For a depth-3 rule with fan-out of 2, that's ~7 round trips — well within the spec floor of D=8 / F=1024 (ADR 0007).
+
+### Why not SQL push-down via recursive CTEs
+
+The fully-pushed-down alternative would compile each rule into a single recursive CTE and execute one round trip per `check()`. This is the design SpiceDB uses internally (its "query planner" + "dispatcher"). For Flametrench it is rejected for v0.3:
+
+- **Implementation cost.** Each rule shape (`computed_userset`, `tuple_to_userset`, nested unions) maps to a different CTE skeleton. Generating these correctly across the parameter ranges adopters use is a multi-month project that is hard to verify against the conformance corpus.
+- **Marginal latency win.** Postgres recursive CTEs against a properly-indexed `tup` table return in single-digit milliseconds. The 7-round-trip iterative approach in the worked example above costs ~3-5ms in a colocated deployment — the saved milliseconds are not the bottleneck.
+- **Rule-evaluation parity.** The iterative approach reuses ADR 0007's algorithm verbatim. Cycle detection, depth bounds, fan-out bounds, and short-circuit semantics are guaranteed identical to the in-memory store — there is nothing to re-prove via conformance fixtures. A push-down implementation would require its own correctness proof per rule shape.
+
+SQL push-down may land in v0.4+ as a `PostgresTupleStore` constructor option for adopters running rule sets with deep chains and high fan-out (the regime where round-trip count actually dominates). It will NOT replace the iterative path — it will be a performance-tuning escape hatch alongside it.
+
+### SDK API: async-capable rule evaluator
+
+The internal `evaluate()` function defined per SDK in `rewrite-rules.{ts,php,py,java}` MUST accept async tuple-lookup callbacks. Concretely:
+
+- **Node**: `DirectLookup` and `ListByObject` callbacks return `Promise<...>` (in v0.2 they returned the value directly). `evaluate()` returns `Promise<EvaluationResult>`. The in-memory store passes `Promise.resolve(...)`-wrapped synchronous lookups.
+- **PHP**: callbacks remain synchronous (PHP has no async). `PostgresTupleStore` issues blocking PDO queries inside the callbacks. No interface change needed; the existing `evaluate()` works as-is once `PostgresTupleStore` implements the callbacks.
+- **Python**: callbacks remain synchronous. Same as PHP — psycopg3's blocking API is fine; the iterative algorithm is naturally sequential.
+- **Java**: callbacks remain synchronous (the SDK is JDBC-based, blocking by design). No interface change; `PostgresTupleStore` implements the callbacks against `Connection`.
+
+Only the Node interface changes shape (the others were already synchronous and Postgres lookups can run synchronously inside them). Adopters who held a reference to `evaluate()` in TypeScript see a compile-time error; the migration is to `await` the result.
+
+### `PostgresTupleStore.check()` becomes rule-aware
+
+The v0.2 `PostgresTupleStore` constructor accepted a `pool` (Node) / `pdo` (PHP) / `connection` (Python) / `dataSource` (Java) and nothing else. v0.3 adds an optional `rules` parameter, mirroring `InMemoryTupleStore`. With `rules` unset (or empty), `check()` behavior is byte-identical to v0.2 — the v0.1 conformance fixtures pass unchanged.
+
+```ts
+// Node v0.3
+new PostgresTupleStore({ pool, rules: loadedRules });
+```
+
+```php
+// PHP v0.3
+new PostgresTupleStore($pdo, rules: $loadedRules);
+```
+
+```python
+# Python v0.3
+PostgresTupleStore(connection, rules=loaded_rules)
+```
+
+```java
+// Java v0.3
+new PostgresTupleStore(dataSource, loadedRules);
+```
+
+When `rules` is set, `check()` dispatches to the rule evaluator on direct-lookup miss, exactly as `InMemoryTupleStore` does today.
+
+### `checkAny()` over a relation set
+
+ADR 0001 introduced `checkAny()` for "is the subject in any of these relations" queries. v0.2's `PostgresTupleStore` implemented it as a single SQL `relation = ANY($3)` predicate. v0.3 keeps the v0.2 implementation as the fast path: when no rule matches any relation in the set, the single SQL query short-circuits before any rule expansion. When at least one relation has a rule, the implementation MUST evaluate each relation in turn until the first match (or all rejected) — there is NO union-of-rules optimization in v0.3.
+
+### Cycle detection in async evaluation
+
+The cycle-detection rule from ADR 0007 (per-evaluation stack of `(relation, objectType, objectId)` frames; repeat-frame returns `denied`) is unchanged. Implementations MUST track the stack across async boundaries — TypeScript adopters, in particular, MUST NOT lose the stack to an `await` that drops the closure.
+
+### Conformance contract update
+
+The v0.2 conformance fixture `empty-rules-equals-v01.json` is now load-bearing for `PostgresTupleStore` too: a `PostgresTupleStore` constructed without a `rules` argument MUST pass the v0.1 conformance corpus identically to `InMemoryTupleStore` constructed without rules.
+
+The full v0.2 rewrite-rules fixture corpus (`union-of-direct.json`, `computed-userset-chain.json`, `tuple-to-userset-parent.json`, `cycle-self-reference.json`, `depth-limit-exceeded.json`, `fan-out-limit-exceeded.json`) MUST also pass against `PostgresTupleStore` configured with the corresponding rule set. SDK conformance runners gain a `--postgres` mode that exercises the same fixtures against a real database.
+
+## Consequences
+
+- `PostgresTupleStore` becomes equivalent to `InMemoryTupleStore` in expressive power. Adopters with rules-based authorization can use Postgres durability without the in-memory shadow workaround.
+- Per-check round-trip count grows from 1 to O(rule_depth × fan-out_per_step). For rule sets at the spec floor recommendation (depth ≤ 4, fan-out ≤ 256), the practical cost is 5-15ms in a colocated deployment.
+- The Node SDK's `rewrite-rules.ts` evaluator is no longer synchronous. Adopters who call `evaluate()` directly (a small set; most use `tupleStore.check()`) MUST migrate to `await evaluate(...)`. The change is mechanical — nothing about the algorithm itself changes.
+- The cross-SDK rewrite-rule fixture corpus, which previously ran only against in-memory stores, now runs against Postgres adapters too. This catches a class of bugs (subtle off-by-one in fan-out enumeration, cycle-detection stack lifecycle across awaits) that the in-memory tests can't surface.
+- ADR 0007's "Deferred / Rule storage in Postgres" bullet — about persisting *rule definitions* in Postgres — remains deferred. This ADR addresses *evaluation* against Postgres-stored *tuples*; rule-definition storage in YAML/JSON at construction time is unchanged.
+
+## Deferred
+
+- **SQL push-down** (recursive CTE per rule). v0.4+ optimization once an adopter's rule profile demonstrates the round-trip count is the bottleneck.
+- **Async rule evaluation in PHP/Python/Java** via the language's coroutine/async story (PHP Fibers, Python asyncio, Java virtual threads). The SDK base in v0.3 stays blocking — async wrappers are a v0.4+ concern.
+- **Cross-process query batching.** Multiple concurrent `check()` calls for the same `(subject, *, object)` could share their rule expansion across SDK instances via a Redis-backed dispatcher. Out of scope for v0.3; tracked as a v0.4+ note.
+- **Rule-evaluation tracing.** A debug API that returns the matched rule path (`this` ⇒ `computed_userset(editor)` ⇒ direct hit) for diagnostics. Useful for adopters writing complex rule sets; not gating v0.3.
+
+## Rejected alternatives
+
+### SQL push-down via per-rule recursive CTEs
+
+Discussed in §"Why not SQL push-down via recursive CTEs" above. Rejected for v0.3 on implementation cost and marginal latency win; revisit in v0.4+ as an opt-in escape hatch.
+
+### Materialized rule-expansion table
+
+A background job pre-computes and writes `(subject, relation, object)` rows for every rule match into a `tup_materialized` companion table. `check()` then becomes a single SELECT against the materialized table.
+
+Rejected: writes are O(rule_fan_out) on every tuple insertion; the materialized table can become an order of magnitude larger than `tup`; staleness windows make `check()` results lag tuple writes. Adopters who need this latency profile can build it in their application layer; the SDK should not make it a default.
+
+### Synchronous Node API (unchanged from v0.2)
+
+The Node `evaluate()` could keep its synchronous shape, with `PostgresTupleStore` blocking on a synchronous query helper. Rejected: there is no synchronous query API in `pg` (the Node Postgres client), and adopting one would force a different driver. The `Promise<>`-returning API is the natural Node shape and matches how every other Node async primitive is composed.
+
+## References
+
+- [ADR 0001](./0001-authorization-model.md) — Authorization model: relational tuples, explicit only.
+- [ADR 0007](./0007-authorization-rewrite-rules.md) — Authorization rewrite rules (defines the evaluation algorithm this ADR adapts to async).
+- [ADR 0013](./0013-postgres-adapter-transaction-nesting.md) — Postgres adapter transaction nesting (for the SAVEPOINT cooperation pattern).
+- `docs/authorization.md` — chapter on authorization, updated by this ADR.
+- Zanzibar paper, §3 ("Architecture: Aclservers and Watch") — for the dispatcher / iterative-resolution pattern Flametrench adopts in microcosm.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -35,6 +35,7 @@ ADRs are numbered sequentially from 0001 in the order accepted. Numbers never ch
 | [0014](./0014-user-display-name.md) | User display name (v0.2 — Proposed) | Adds optional `display_name` to `User`; new `updateUser` operation; closes spec#9 |
 | [0015](./0015-list-users.md) | IdentityStore.listUsers (v0.2 — Proposed) | Cursor-paginated user enumeration with status filter and credential-identifier substring; mirrors `listMembers`; closes spec#10 |
 | [0016](./0016-personal-access-tokens.md) | Personal access tokens (v0.3 — Proposed) | New `pat` primitive for non-interactive (CLI / CI / server-to-server) auth; id-then-secret wire format with prefix-routed bearer dispatch; Argon2id storage; `auth.kind` audit discriminator; closes spec#14 |
+| [0017](./0017-postgres-rewrite-rule-evaluation.md) | Postgres rewrite-rule evaluation (v0.3 — Proposed) | `PostgresTupleStore` gains rule-aware `check()` via iterative async expansion (not SQL push-down); Node `evaluate()` becomes async-capable; retires the v0.2 deferral in `docs/authorization.md` |
 
 ## Writing a new ADR
 

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -96,7 +96,7 @@ If an application's authorization policy requires any of these derivations, thre
 
 ## Rewrite rules (v0.2)
 
-The design is normative as of v0.2 and is locked in [ADR 0007](../decisions/0007-authorization-rewrite-rules.md). All four SDK families ship in-memory rewrite-rule support in their v0.2 release-candidate. Postgres-backed rule evaluation is deferred to v0.3 — adopters who need Postgres durability today can keep the rules-relevant tuple subset in-memory and use the in-memory `check()` for those queries.
+The design is normative as of v0.2 and is locked in [ADR 0007](../decisions/0007-authorization-rewrite-rules.md). All four SDK families ship in-memory rewrite-rule support in their v0.2 release-candidate. v0.3 retires the Postgres deferral: `PostgresTupleStore.check()` accepts the same `rules` option as `InMemoryTupleStore` and evaluates via iterative async expansion (per [ADR 0017](../decisions/0017-postgres-rewrite-rule-evaluation.md)). Adopters who need Postgres durability with rules can now use `PostgresTupleStore({ pool, rules })` directly — no in-memory shadow workaround required.
 
 ### Why
 


### PR DESCRIPTION
Retires the v0.2 deferral in \`docs/authorization.md\` that left \`PostgresTupleStore\` exact-match-only. v0.3 adds rule-aware \`check()\` via iterative async expansion (mirrors ADR 0007's algorithm verbatim against async DB queries), so Postgres-backed adopters can use rewrite rules without the in-memory shadow workaround.

## Summary
- \`decisions/0017-postgres-rewrite-rule-evaluation.md\` (~140 lines) — rationale, evaluation strategy, per-language API impact, deferred items, rejected alternatives (SQL push-down + materialized rule-expansion).
- \`docs/authorization.md\` — deferral paragraph rewritten.
- \`decisions/README.md\` + \`CHANGELOG.md\` — ADR 0017 indexed; CHANGELOG gains the Node API change note.

## Key decisions pinned
- **Iterative**, not push-down. Round-trip count isn't the bottleneck on properly-indexed \`tup\` tables; CTE generation per rule shape is multi-month work that would have to re-prove ADR 0007 correctness.
- **Node \`evaluate()\` becomes async-capable** — callbacks return \`Promise<...>\`. PHP/Python/Java keep synchronous callbacks (the natural shape for blocking JDBC/PDO/psycopg).
- \`PostgresTupleStore\` constructor in all 4 SDKs gains an optional \`rules\` parameter mirroring \`InMemoryTupleStore\`. Empty rules ⇒ v0.2-identical behavior.
- v0.2 rewrite-rules fixture corpus MUST now pass against \`PostgresTupleStore\` too.

## What this PR does NOT do
- The SDK ports themselves. ADR lands first so the contract is fixed; per-SDK implementation PRs follow.

## Test plan
- [ ] Read end-to-end as the source of truth before SDK ports begin.
- [ ] Skim \`docs/authorization.md\` to confirm the deferral paragraph reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)