### PR TITLE
spec hygiene: register pat prefix in ids.md + record ADR numbering discipline

### DIFF
--- a/decisions/README.md
+++ b/decisions/README.md
@@ -15,6 +15,8 @@ ADRs are historical: once accepted, the content of an ADR is frozen. Future desi
 
 ADRs are numbered sequentially from 0001 in the order accepted. Numbers never change, are never reused, and are never reclaimed from withdrawn ADRs.
 
+**Drafts are number-less.** Because the number is determined by *acceptance order* — not by when drafting begins — do not bake an ADR number into a draft (filename, title, or cross-references) while it is still being written. Refer to a pending ADR by its primitive/topic name. **Assign the next free number at PR-open time**, in the order PRs are opened for merge, and open **one ADR per PR**. This prevents the collision class where two concurrently-drafted ADRs (or an adopter's externally-numbered draft) both claim the same number and one has to be renumbered late. A number is only *fixed* once its PR merges.
+
 ## Current ADRs
 
 | # | Title | Topic |

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -56,7 +56,7 @@ Consistent casing guarantees byte-identical encodings across SDKs and simplifies
 
 ## Type prefix registry
 
-The following type prefixes are reserved by the current specification (v0.2):
+The following type prefixes are registered by the current specification:
 
 | Prefix | Resource                | Capability                               |
 | ------ | ----------------------- | ---------------------------------------- |
@@ -69,6 +69,9 @@ The following type prefixes are reserved by the current specification (v0.2):
 | `inv`  | Invitation              | Tenancy                                  |
 | `tup`  | Authorization tuple     | Authorization                            |
 | `shr`  | Share token             | Authorization (v0.2; ADR 0012)           |
+| `pat`  | Personal access token   | Identity (v0.3; ADR 0016)                |
+
+The `pat` bearer token uses a two-part `pat_<32hex-id>_<secret>` wire format (id-then-secret, split on the second underscore — the base64url secret MAY itself contain `_`/`-`); see [ADR 0016](../decisions/0016-personal-access-tokens.md) for the normative format and verification rules. The `pat_<32hex>` row identifier follows the standard `{type}_{hex}` encoding above.
 
 Implementations MUST NOT invent new type prefixes. New prefixes are added by amending this document through the specification's change process.
 


### PR DESCRIPTION
Two small, doc-only spec-ownership fixes, both surfaced during the www docs PR #3 spec-accuracy review.

## 1. Register `pat` in `docs/ids.md` (clerical sync to ADR 0016)
ADR 0016 (Personal access tokens, **Accepted**, v0.3) states the `pat` prefix 'moves from reserved to active in the ID prefix registry' — but the normative registry in `docs/ids.md` was never amended; the active table stopped at `shr`. Per ids.md's own rule ('Implementations MUST NOT invent new type prefixes. New prefixes are added by amending this document'), `pat_` was technically unregistered despite being shipped in v0.3.

This is **not a new decision** — it propagates an already-accepted ADR. Adds the `pat` row, a pointer to 0016's two-part `pat_<32hex>_<secret>` wire format (incl. the split-on-second-underscore rule, since the base64url secret may contain `_`), and drops the stale `(v0.2)` qualifier on the registry header.

The www docs (PR #3) had correctly listed `pat_` per ADR 0016 — i.e. the public docs were ahead of the spec's own source. This closes that drift.

## 2. Record the number-less ADR drafting discipline (`decisions/README.md`)
PM-requested. Documents: draft number-less, assign the next free number at PR-open in acceptance order, one ADR per PR. Makes durable the fix for the 0014–0017 / 0018 numbering-collision class.

Both are doc-only and within spec ownership; provenance noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)