### PR TITLE
decisions: notifications primitive (not) for v0.4

### DIFF
--- a/decisions/0022-notify-primitive.md
+++ b/decisions/0022-notify-primitive.md
@@ -1,11 +1,9 @@
-# Notifications primitive (`not`)
+# 0022 — Notifications primitive (`not`)
 
 **Status:** Proposed (v0.4)
 **Date:** 2026-06-05
 **Deciders:** Flametrench stewards
 **Filed by:** SiteSource (primary consumer)
-
-> Number-less draft: the ADR number is assigned at PR-open / acceptance per the `decisions/README.md` numbering rule.
 
 ## Context
 

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -42,6 +42,7 @@ ADRs are numbered sequentially from 0001 in the order accepted. Numbers never ch
 | [0019](./0019-audit-primitive.md) | Audit primitive (`aud`) (v0.4 — Proposed) | Append-only action log; fulfills ADR 0016's forward reference for the `aud` primitive, event schema, and `auth.kind = system`; `on_behalf` for delegated non-human actors (orthogonal to `auth.kind`); denied-op cross-scope non-disclosure; promotes `aud` in `docs/ids.md`. Filed by SiteSource |
 | [0020](./0020-file-metadata-primitive.md) | File-metadata primitive (`file`) (v0.4 — Proposed) | `file_` metadata + lifecycle, storage-agnostic (opaque `storage_ref`, no blob bytes); access via `authz.check()` on the file as an object — no parallel ACL; emits `aud`; promotes `file` in `docs/ids.md`. Filed by SiteSource |
 | [0021](./0021-flags-primitive.md) | Feature-flags primitive (`flag`) (v0.4 — Proposed) | Boolean flags + ordered targeting rules; targeting reuses `authz` `check()`/tuples (no new DSL); deterministic SHA-256 bucketing pinned for cross-SDK identity; `evaluate` hot-path/unaudited; emits `aud`; promotes `flag` in `docs/ids.md`. Filed by SiteSource |
+| [0022](./0022-notify-primitive.md) | Notifications primitive (`not`) (v0.4 — Proposed) | Per-recipient record/event primitive (NOT a delivery engine — no SMTP/SMS/push/templating/retry); lifecycle `unread ⇄ read → dismissed`; strictly recipient-scoped access; emits `aud`; promotes `not` in `docs/ids.md`. Filed by SiteSource |
 
 ## Writing a new ADR
 

--- a/decisions/notify-primitive.md
+++ b/decisions/notify-primitive.md
@@ -1,0 +1,132 @@
+# Notifications primitive (`not`)
+
+**Status:** Proposed (v0.4)
+**Date:** 2026-06-05
+**Deciders:** Flametrench stewards
+**Filed by:** SiteSource (primary consumer)
+
+> Number-less draft: the ADR number is assigned at PR-open / acceptance per the `decisions/README.md` numbering rule.
+
+## Context
+
+Applications need to tell users about things: a mention, an invitation, an approval request, a job finishing. The durable part of that — *"there is a thing user U should be told about, and U has/hasn't seen it"* — is a small, universal record. The variable part — *how* the user is told (email, SMS, push, in-app), with what copy, retried how — is large, provider-specific, and changes per adopter.
+
+Flametrench owns the small, universal part and **deliberately not** the large variable part. This is the notify analog of "file-metadata is not a blob store": **notify is a record/event primitive, not a delivery engine.** This boundary is an operator-authoritative spec line, not an appetite preference.
+
+This is one of four v0.4 primitives; this ADR is **notifications only**. It depends on the audit primitive (`aud`) for emission and respects `tenancy` (ADR 0002) boundaries.
+
+## Decision
+
+Add `not` (notification) as a Flametrench **v0.4** primitive: a per-recipient record that something happened, with read-state, plus the event of its creation. The `not` prefix moves from "Reserved" to active in [`docs/ids.md`](../docs/ids.md) (v0.4; this ADR amends it).
+
+### The boundary (normative)
+
+- **In scope:** the `not_` record ("a thing a user should be told about"), its lifecycle state (`unread` → `read` → `dismissed`), and the **event of creation** (a notification coming into existence is the signal adopters react to).
+- **Out of scope — hard NO at the primitive layer:** SMTP/SMS/push provider integration, message **templating/rendering**, and **retry/backoff/delivery orchestration**. An adopter's delivery layer subscribes to the creation event and decides whether to email/push/etc.; the primitive neither performs nor models delivery. A draft that scopes notify as a delivery system is out of bounds by construction.
+
+### Entity shape
+
+```
+Notification = {
+  id:             not_<32hex>          // wire; UUIDv7 underneath
+  scope:          org_<32hex>          // owning tenancy scope
+  recipient_usr_id: usr_<32hex>        // the user who should be told
+  type:           string               // adopter-namespaced kind ("comment.mention", "invite.received"); opaque
+  subject:        { kind: string, id: string }   // what it is about; Flametrench id (decodable) OR opaque adopter id
+  data:           object               // free-form record content for the adopter's own rendering; ≤ 16 KB. NOT a template.
+  state:          "unread"|"read"|"dismissed"
+  created_at:     timestamptz
+  state_changed_at: timestamptz        // updated on each state transition
+}
+```
+
+**Example:**
+
+```json
+{
+  "id": "not_0190f2a81b3c7abc8123000000000030",
+  "scope": "org_0190f2a81b3c7abc8123000000000004",
+  "recipient_usr_id": "usr_0190f2a81b3c7abc8123000000000002",
+  "type": "comment.mention",
+  "subject": { "kind": "doc", "id": "doc_2f9c1a..." },
+  "data": { "actor_name": "Alice", "snippet": "…@bob take a look" },
+  "state": "unread",
+  "created_at": "2026-06-05T10:00:00.000Z",
+  "state_changed_at": "2026-06-05T10:00:00.000Z"
+}
+```
+
+`data` is the record's content for the adopter to render however it delivers — it is plain data, **not** a template string and **not** rendered by the primitive.
+
+### Lifecycle (normative)
+
+A notification's `state` is a small machine:
+
+- Created as `unread`.
+- `unread ⇄ read` — `markRead` / `markUnread` may toggle either direction (a user re-flagging an item as unread is a real pattern).
+- `read | unread → dismissed` — `dismiss` is **terminal**; a dismissed notification accepts no further state change.
+
+Every transition updates `state_changed_at`.
+
+### The creation event
+
+Creating a notification **is** the event adopters react to. The primitive guarantees the record exists durably on `createNotification` return; an adopter's delivery layer observes new notifications (via its own subscription/poll or a future realtime mechanism) and performs whatever out-of-scope delivery it wants. The primitive does **not** define a delivery callback, a provider interface, or a retry contract.
+
+### Operations
+
+| Operation | Description |
+|---|---|
+| `createNotification` | Create a notification for a recipient; emits `aud`. |
+| `getNotification` | Fetch by id. |
+| `listNotifications` | Cursor-paginated **inbox** for a `recipient_usr_id` within a scope; filterable by `state`, `type`. |
+| `countUnread` | Count `unread` notifications for a recipient (badge counts). |
+| `markRead` / `markUnread` | Toggle read state. |
+| `dismiss` | Terminal-dismiss a notification. |
+
+A recipient may only read and transition **their own** notifications; cross-recipient access requires the appropriate authz and is otherwise denied.
+
+### Audit emission
+
+`createNotification` and `dismiss` MUST emit an `aud` event (`action ∈ {"notify.create","notify.dismiss"}`, `target = { kind: "not", id: not_<id> }`, scope, outcome). High-frequency routine transitions (`markRead`/`markUnread`) need not each emit an event (adopters MAY enable it). A denied access follows the audit primitive's cross-scope non-disclosure rule.
+
+### Tenancy non-inference (normative)
+
+A notification is scoped to one `org` and addressed to one recipient. The `listNotifications`/`countUnread`/`get` surface MUST NOT let a caller observe notifications outside their own recipient scope, and a cross-scope or cross-recipient probe MUST NOT disclose the existence of a foreign notification (presence, count, or error-code differential) — the same existence-oracle discipline the audit primitive applies to denied operations.
+
+### Constraints (normative)
+
+- `id` is `not_<32hex>` per `docs/ids.md`.
+- `type` is an adopter-namespaced string, opaque to the primitive (`^[a-z0-9._-]{1,64}$`).
+- `subject.id` follows the Flametrench-vs-adopter id split (decodable Flametrench ids; opaque adopter ids).
+- `data` is a JSON object ≤ 16 KB. The primitive stores and returns it; it does not interpret or render it.
+
+## Consequences
+
+**Positive:**
+- Every adopter gets a durable, per-user, read-stateful notification record + inbox queries + badge counts — the part everyone rebuilds — without Flametrench taking on provider integrations it would do worse than dedicated services.
+- The creation-event seam lets adopters plug any delivery stack (Postmark, SES, FCM, a websocket) without the primitive constraining them.
+- Read-state and tenancy non-inference are pinned once, correctly.
+
+**Negative:**
+- Delivery is entirely the adopter's — the primitive offers no "send an email" convenience. Deliberate; it's the boundary. Adopters wanting batteries-included delivery layer it on top.
+- No cross-channel dedup / preference center in v0.4 (deferred).
+
+## Deferred
+
+- **Delivery, templating, provider integration, retry** — out of scope **permanently**, not deferred.
+- **Notification preferences / channels / digesting** (per-user "email me mentions, don't email me likes") — a useful adjacent capability, deferred pending demand; it is preference state, still not delivery.
+- **Grouping / threading** (collapsing N "liked your post" into one) — adopter-side or a later extension.
+- **A first-class realtime push of the creation event** — depends on a separate realtime/subscription mechanism Flametrench does not yet have; v0.4 adopters poll or wire their own.
+
+## Rejected alternatives
+
+- **A delivery engine** (SMTP/SMS/push, templating, retry). Rejected — operator-authoritative boundary; provider integration is large, fast-moving, and better served by dedicated services. The primitive is the record + state + creation event.
+- **A shared rendered "message" string instead of structured `data`.** Rejected — rendering is delivery-channel-specific (an email body ≠ a push title); the primitive carries structured data and lets each channel render.
+- **Global (no-recipient) broadcasts as `not_` records.** Rejected for v0.4 — fan-out/broadcast is a different shape; v0.4 notifications are per-recipient. A broadcast primitive can come later.
+
+## References
+
+- Audit primitive (`aud`, v0.4): `notify.*` lifecycle emits `aud` events; the cross-scope non-disclosure rule applies.
+- [ADR 0002 — Tenancy model](./0002-tenancy-model.md): the org-scope and recipient boundaries this primitive respects.
+- [`docs/ids.md`](../docs/ids.md): `not` promoted Reserved → active (v0.4; this ADR amends it).
+- Project README: Flametrench does not own provider/delivery infrastructure — the principle behind the notify boundary.

--- a/decisions/notify-primitive.md
+++ b/decisions/notify-primitive.md
@@ -13,7 +13,7 @@ Applications need to tell users about things: a mention, an invitation, an appro
 
 Flametrench owns the small, universal part and **deliberately not** the large variable part. This is the notify analog of "file-metadata is not a blob store": **notify is a record/event primitive, not a delivery engine.** This boundary is an operator-authoritative spec line, not an appetite preference.
 
-This is one of four v0.4 primitives; this ADR is **notifications only**. It depends on the audit primitive (`aud`) for emission and respects `tenancy` (ADR 0002) boundaries.
+This is one of four v0.4 primitives; this ADR is **notifications only**. It depends on [ADR 0019](./0019-audit-primitive.md) (the `aud` audit primitive) for emission and respects `tenancy` (ADR 0002) boundaries.
 
 ## Decision
 
@@ -83,15 +83,17 @@ Creating a notification **is** the event adopters react to. The primitive guaran
 | `markRead` / `markUnread` | Toggle read state. |
 | `dismiss` | Terminal-dismiss a notification. |
 
-A recipient may only read and transition **their own** notifications; cross-recipient access requires the appropriate authz and is otherwise denied.
+### Access — strictly recipient-scoped (normative)
+
+A notification is **not** a general authz object. Access is **strictly bound to the recipient**, like a `ses_` is bound to its user: `get`, `listNotifications`, `countUnread`, `markRead`, `markUnread`, and `dismiss` operate **only** on notifications whose `recipient_usr_id` is the authenticated caller. An operation targeting another user's notification is denied as if it did not exist (per the tenancy-non-inference rule below) — there is no cross-recipient read path in the primitive. Administrative or "see all notifications in an org" views are an **adopter concern** layered outside this primitive (e.g. the adopter queries its own store, or models an admin capability via `authz` on a different object); the `not` primitive itself exposes only the recipient's own inbox.
 
 ### Audit emission
 
-`createNotification` and `dismiss` MUST emit an `aud` event (`action ∈ {"notify.create","notify.dismiss"}`, `target = { kind: "not", id: not_<id> }`, scope, outcome). High-frequency routine transitions (`markRead`/`markUnread`) need not each emit an event (adopters MAY enable it). A denied access follows the audit primitive's cross-scope non-disclosure rule.
+`createNotification` and `dismiss` MUST emit an `aud` event (`action ∈ {"notify.create","notify.dismiss"}`, `target = { kind: "not", id: not_<id> }`, scope, outcome). High-frequency routine transitions (`markRead`/`markUnread`) need not each emit an event (adopters MAY enable it). A denied access follows ADR 0019's cross-scope non-disclosure rule.
 
 ### Tenancy non-inference (normative)
 
-A notification is scoped to one `org` and addressed to one recipient. The `listNotifications`/`countUnread`/`get` surface MUST NOT let a caller observe notifications outside their own recipient scope, and a cross-scope or cross-recipient probe MUST NOT disclose the existence of a foreign notification (presence, count, or error-code differential) — the same existence-oracle discipline the audit primitive applies to denied operations.
+A notification is scoped to one `org` and addressed to one recipient. The `listNotifications`/`countUnread`/`get` surface MUST NOT let a caller observe notifications outside their own recipient scope, and a cross-scope or cross-recipient probe MUST NOT disclose the existence of a foreign notification (presence, count, or error-code differential) — the same existence-oracle discipline ADR 0019 applies to denied operations.
 
 ### Constraints (normative)
 
@@ -126,7 +128,7 @@ A notification is scoped to one `org` and addressed to one recipient. The `listN
 
 ## References
 
-- Audit primitive (`aud`, v0.4): `notify.*` lifecycle emits `aud` events; the cross-scope non-disclosure rule applies.
+- [ADR 0019 — Audit primitive (`aud`)](./0019-audit-primitive.md): `notify.*` lifecycle emits `aud` events; the cross-scope non-disclosure rule applies.
 - [ADR 0002 — Tenancy model](./0002-tenancy-model.md): the org-scope and recipient boundaries this primitive respects.
 - [`docs/ids.md`](../docs/ids.md): `not` promoted Reserved → active (v0.4; this ADR amends it).
 - Project README: Flametrench does not own provider/delivery infrastructure — the principle behind the notify boundary.

--- a/docs/ids.md
+++ b/docs/ids.md
@@ -73,6 +73,7 @@ The following type prefixes are registered by the current specification:
 | `aud`  | Audit event             | Audit (v0.4; ADR 0019)                   |
 | `file` | File metadata           | Files (v0.4; ADR 0020)                   |
 | `flag` | Feature flag            | Feature flags (v0.4; ADR 0021)           |
+| `not`  | Notification            | Notifications (v0.4; ADR 0022)           |
 
 The `pat` bearer token uses a two-part `pat_<32hex-id>_<secret>` wire format (id-then-secret, split on the second underscore — the base64url secret MAY itself contain `_`/`-`); see [ADR 0016](../decisions/0016-personal-access-tokens.md) for the normative format and verification rules. The `pat_<32hex>` row identifier follows the standard `{type}_{hex}` encoding above.
 
@@ -82,7 +83,6 @@ Reserved prefixes for future capabilities (not usable in v0.2 implementations):
 
 | Prefix  | Planned resource        | Capability      | Status        |
 | ------- | ----------------------- | --------------- | ------------- |
-| `not`   | Notification            | Notifications   | Reserved      |
 | `sub`   | Subscription            | Billing         | Reserved      |
 
 Prefix selection rules for future additions:


### PR DESCRIPTION
Filed by SiteSource (`sitesource-platform-spec`), third of the three behind audit. Tagging @flametrench-spec. **Number-less** per your numbering rule.

## What
The `not` notifications primitive for v0.4 — drafted as a **record/event primitive, not a delivery engine**, per the now operator-authoritative boundary:

- **In scope:** the `not_` record ("a thing a user should be told about"), lifecycle (`unread ⇄ read → dismissed` terminal), and the **creation event** adopters react to.
- **Out — hard NO:** SMTP/SMS/push providers, templating/rendering, retry/delivery orchestration. An adopter's delivery layer subscribes to the creation event and does its own thing; the primitive neither performs nor models delivery. (The notify analog of "file-metadata isn't a blob store.")

`data` is structured record content (≤16 KB) for the adopter to render per channel — **not** a template the primitive renders.

## Conventions
- Operations: create / get / list (inbox) / countUnread / markRead / markUnread / dismiss. `create` + `dismiss` emit **`aud`** events; routine `markRead` toggles aren't each audited.
- **Tenancy non-inference:** a cross-recipient/cross-scope probe MUST NOT disclose a foreign notification's existence (presence/count/error-code) — audit's denied-op discipline.
- `not` promoted Reserved → active in `docs/ids.md` (v0.4); canonical ids; your template + RFC 2119 + example.
- Preferences/channels/digesting, grouping, and a realtime push of the creation event are explicitly **deferred** (and delivery is out *permanently*).

## Sequencing
This completes the trio (file-metadata #30 → flags #31 → **notify, this**), all behind audit (#28), which stays the keystone/priority. Each emits `aud` on 0019's schema. Held the `decisions/README.md` index rows pending your number assignment. Notify is the one you said you'd scrutinize hardest — I kept it to the record/event slice; tell me where you want it tighter.