### PR TITLE
ci(conformance): build ids dep from source (not registry) + fix list-users fixture

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -189,13 +189,14 @@ jobs:
           path: sdk
 
       - name: Checkout flametrench/ids-python
-        # ids-python is the upstream dep for the other Python SDKs;
-        # bootstrap it from the sibling repo until v0.2.x is on PyPI.
+        # ids-python is the upstream dep for the other Python SDKs. Build it
+        # from the sibling repo's default branch — version-coordinated with the
+        # SDK under test — rather than a pinned (and stale) tag or PyPI, which
+        # is not yet published. CI must not depend on an unpublished registry.
         if: matrix.sdk != 'ids-python'
         uses: actions/checkout@v4
         with:
           repository: flametrench/ids-python
-          ref: v0.2.0rc3
           path: _vendored/ids-python
 
       - name: Overlay live spec fixtures
@@ -233,15 +234,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - sdk: ids-java
-            ids_ref: v0.2.0-rc.2
-          - sdk: identity-java
-            ids_ref: v0.2.0-rc.1
-          - sdk: tenancy-java
-            ids_ref: v0.1.0
-          - sdk: authz-java
-            ids_ref: v0.2.0-rc.2
+        sdk: [ids-java, identity-java, tenancy-java, authz-java]
     steps:
       - name: Checkout spec
         uses: actions/checkout@v4
@@ -255,11 +248,15 @@ jobs:
           path: sdk
 
       - name: Checkout flametrench/ids-java
+        # Build the ids dep from ids-java's default branch — version-coordinated
+        # with the SDK under test — instead of a pinned (stale) tag. The SDK
+        # poms depend on dev.flametrench:ids at the current development version;
+        # resolving it from Maven Central fails because we have not published
+        # there. CI must not depend on an unpublished registry.
         if: matrix.sdk != 'ids-java'
         uses: actions/checkout@v4
         with:
           repository: flametrench/ids-java
-          ref: ${{ matrix.ids_ref }}
           path: _vendored/ids-java
 
       - name: Overlay live spec fixtures

--- a/conformance/fixtures/identity/list-users.json
+++ b/conformance/fixtures/identity/list-users.json
@@ -12,15 +12,39 @@
       "description": "list_users with no filters returns all users in id ASC order. UUIDv7 makes this approximately creation-time-ordered.",
       "users": [],
       "steps": [
-        { "op": "create_user", "captures": { "u1": "user.id" } },
-        { "op": "create_user", "captures": { "u2": "user.id" } },
-        { "op": "create_user", "captures": { "u3": "user.id" } },
+        {
+          "op": "create_user",
+          "captures": {
+            "u1": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u2": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u3": "user.id"
+          },
+          "input": {}
+        },
         {
           "op": "list_users",
           "input": {},
           "expected": {
-            "data_ids_in_order": ["{u1}", "{u2}", "{u3}"],
-            "next_cursor": null
+            "result": {
+              "data_ids_in_order": [
+                "{u1}",
+                "{u2}",
+                "{u3}"
+              ],
+              "next_cursor": null
+            }
           }
         }
       ]
@@ -30,21 +54,50 @@
       "description": "Filtering by status returns only matching users. Suspended users are excluded when status='active'.",
       "users": [],
       "steps": [
-        { "op": "create_user", "captures": { "active_id": "user.id" } },
-        { "op": "create_user", "captures": { "suspended_id": "user.id" } },
-        { "op": "suspend_user", "input": { "usr_id": "{suspended_id}" } },
         {
-          "op": "list_users",
-          "input": { "status": "active" },
-          "expected": {
-            "data_ids_in_order": ["{active_id}"]
+          "op": "create_user",
+          "captures": {
+            "active_id": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "suspended_id": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "suspend_user",
+          "input": {
+            "usr_id": "{suspended_id}"
           }
         },
         {
           "op": "list_users",
-          "input": { "status": "suspended" },
+          "input": {
+            "status": "active"
+          },
           "expected": {
-            "data_ids_in_order": ["{suspended_id}"]
+            "result": {
+              "data_ids_in_order": [
+                "{active_id}"
+              ]
+            }
+          }
+        },
+        {
+          "op": "list_users",
+          "input": {
+            "status": "suspended"
+          },
+          "expected": {
+            "result": {
+              "data_ids_in_order": [
+                "{suspended_id}"
+              ]
+            }
           }
         }
       ]
@@ -54,14 +107,37 @@
       "description": "Revoked users appear under status='revoked' but are excluded by default-active filter.",
       "users": [],
       "steps": [
-        { "op": "create_user", "captures": { "live_id": "user.id" } },
-        { "op": "create_user", "captures": { "dead_id": "user.id" } },
-        { "op": "revoke_user", "input": { "usr_id": "{dead_id}" } },
+        {
+          "op": "create_user",
+          "captures": {
+            "live_id": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "dead_id": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "revoke_user",
+          "input": {
+            "usr_id": "{dead_id}"
+          }
+        },
         {
           "op": "list_users",
-          "input": { "status": "revoked" },
+          "input": {
+            "status": "revoked"
+          },
           "expected": {
-            "data_ids_in_order": ["{dead_id}"]
+            "result": {
+              "data_ids_in_order": [
+                "{dead_id}"
+              ]
+            }
           }
         }
       ]
@@ -73,24 +149,46 @@
       "steps": [
         {
           "op": "create_user_with_password_credential",
-          "input": { "identifier": "alice@example.com", "password": "long-enough-password-for-floor" },
-          "captures": { "alice_id": "user.id" }
+          "input": {
+            "identifier": "alice@example.com",
+            "password": "long-enough-password-for-floor"
+          },
+          "captures": {
+            "alice_id": "user.id"
+          }
         },
         {
           "op": "create_user_with_password_credential",
-          "input": { "identifier": "bob@example.com", "password": "long-enough-password-for-floor" },
-          "captures": { "bob_id": "user.id" }
+          "input": {
+            "identifier": "bob@example.com",
+            "password": "long-enough-password-for-floor"
+          },
+          "captures": {
+            "bob_id": "user.id"
+          }
         },
         {
           "op": "create_user_with_password_credential",
-          "input": { "identifier": "carol@other.test", "password": "long-enough-password-for-floor" },
-          "captures": { "carol_id": "user.id" }
+          "input": {
+            "identifier": "carol@other.test",
+            "password": "long-enough-password-for-floor"
+          },
+          "captures": {
+            "carol_id": "user.id"
+          }
         },
         {
           "op": "list_users",
-          "input": { "query": "example" },
+          "input": {
+            "query": "example"
+          },
           "expected": {
-            "data_ids_unordered": ["{alice_id}", "{bob_id}"]
+            "result": {
+              "data_ids_unordered": [
+                "{alice_id}",
+                "{bob_id}"
+              ]
+            }
           }
         }
       ]
@@ -102,14 +200,25 @@
       "steps": [
         {
           "op": "create_user_with_password_credential",
-          "input": { "identifier": "alice@example.com", "password": "long-enough-password-for-floor" },
-          "captures": { "alice_id": "user.id" }
+          "input": {
+            "identifier": "alice@example.com",
+            "password": "long-enough-password-for-floor"
+          },
+          "captures": {
+            "alice_id": "user.id"
+          }
         },
         {
           "op": "list_users",
-          "input": { "query": "EXAMPLE" },
+          "input": {
+            "query": "EXAMPLE"
+          },
           "expected": {
-            "data_ids_unordered": ["{alice_id}"]
+            "result": {
+              "data_ids_unordered": [
+                "{alice_id}"
+              ]
+            }
           }
         }
       ]
@@ -121,18 +230,30 @@
       "steps": [
         {
           "op": "create_user_with_password_credential",
-          "input": { "identifier": "gone@example.com", "password": "long-enough-password-for-floor" },
-          "captures": { "user_id": "user.id", "cred_id": "credential.id" }
+          "input": {
+            "identifier": "gone@example.com",
+            "password": "long-enough-password-for-floor"
+          },
+          "captures": {
+            "user_id": "user.id",
+            "cred_id": "credential.id"
+          }
         },
         {
           "op": "revoke_credential",
-          "input": { "cred_id": "{cred_id}" }
+          "input": {
+            "cred_id": "{cred_id}"
+          }
         },
         {
           "op": "list_users",
-          "input": { "query": "gone@example.com" },
+          "input": {
+            "query": "gone@example.com"
+          },
           "expected": {
-            "data_ids_unordered": []
+            "result": {
+              "data_ids_unordered": []
+            }
           }
         }
       ]
@@ -142,33 +263,89 @@
       "description": "Calling list_users with the next_cursor returns the next page; the final page returns next_cursor=null.",
       "users": [],
       "steps": [
-        { "op": "create_user", "captures": { "u1": "user.id" } },
-        { "op": "create_user", "captures": { "u2": "user.id" } },
-        { "op": "create_user", "captures": { "u3": "user.id" } },
-        { "op": "create_user", "captures": { "u4": "user.id" } },
-        { "op": "create_user", "captures": { "u5": "user.id" } },
+        {
+          "op": "create_user",
+          "captures": {
+            "u1": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u2": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u3": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u4": "user.id"
+          },
+          "input": {}
+        },
+        {
+          "op": "create_user",
+          "captures": {
+            "u5": "user.id"
+          },
+          "input": {}
+        },
         {
           "op": "list_users",
-          "input": { "limit": 2 },
-          "captures": { "page1_cursor": "page.next_cursor" },
+          "input": {
+            "limit": 2
+          },
+          "captures": {
+            "page1_cursor": "page.next_cursor"
+          },
           "expected": {
-            "data_ids_in_order": ["{u1}", "{u2}"]
+            "result": {
+              "data_ids_in_order": [
+                "{u1}",
+                "{u2}"
+              ]
+            }
           }
         },
         {
           "op": "list_users",
-          "input": { "cursor": "{page1_cursor}", "limit": 2 },
-          "captures": { "page2_cursor": "page.next_cursor" },
+          "input": {
+            "cursor": "{page1_cursor}",
+            "limit": 2
+          },
+          "captures": {
+            "page2_cursor": "page.next_cursor"
+          },
           "expected": {
-            "data_ids_in_order": ["{u3}", "{u4}"]
+            "result": {
+              "data_ids_in_order": [
+                "{u3}",
+                "{u4}"
+              ]
+            }
           }
         },
         {
           "op": "list_users",
-          "input": { "cursor": "{page2_cursor}", "limit": 2 },
+          "input": {
+            "cursor": "{page2_cursor}",
+            "limit": 2
+          },
           "expected": {
-            "data_ids_in_order": ["{u5}"],
-            "next_cursor": null
+            "result": {
+              "data_ids_in_order": [
+                "{u5}"
+              ],
+              "next_cursor": null
+            }
           }
         }
       ]
@@ -182,8 +359,10 @@
           "op": "list_users",
           "input": {},
           "expected": {
-            "data_ids_in_order": [],
-            "next_cursor": null
+            "result": {
+              "data_ids_in_order": [],
+              "next_cursor": null
+            }
           }
         }
       ]
@@ -195,17 +374,29 @@
       "steps": [
         {
           "op": "create_user",
-          "input": { "display_name": "Alice" },
-          "captures": { "alice_id": "user.id" }
+          "input": {
+            "display_name": "Alice"
+          },
+          "captures": {
+            "alice_id": "user.id"
+          }
         },
-        { "op": "create_user", "captures": { "bob_id": "user.id" } },
+        {
+          "op": "create_user",
+          "captures": {
+            "bob_id": "user.id"
+          },
+          "input": {}
+        },
         {
           "op": "list_users",
           "input": {},
           "expected": {
-            "user_display_names": {
-              "{alice_id}": "Alice",
-              "{bob_id}": null
+            "result": {
+              "user_display_names": {
+                "{alice_id}": "Alice",
+                "{bob_id}": null
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes the two failures keeping the **Conformance** workflow red (and the weekly cron emailing the operator). Reported by the PM.

## 1. SDK ids dep resolved from an unpublished registry (Java + Python)
The `sdk-java` jobs built `ids-java` at **stale refs** (`v0.2.0-rc.2` / `rc.1` / `v0.1.0`) that don't match the SDK poms' `dev.flametrench:ids:0.2.0` dependency, so Maven fell through to **Maven Central — which we haven't published to**:
```
Could not find artifact dev.flametrench:ids:jar:0.2.0 in central
```
**Fix:** build the `ids` dep from `ids-java` / `ids-python`'s **default branch** (version-coordinated with the SDK under test) instead of a pinned stale tag. Drops the stale `rc` pins. CI must not depend on an unpublished registry. *(I verified the poms: `identity-java`/`authz-java` require `ids:0.2.0` and `ids-java` main is `0.2.0`, so the dep resolves locally.)*

## 2. `list-users.json` fixture failed schema validation
`missingProperty: 'input'` — the fixture had drifted from `fixture.schema.json`: bare steps without `input`, plus an enumeration-assertion vocabulary (`data_ids_in_order`, …) that **no SDK harness reads** (harnesses read `expected.result`; verified against the Node/Python runners). Brought it into conformance: added `input: {}` to bare steps and moved the assertions under `expected.result`. Non-breaking (no current consumer reads the old shape).

**Local verification:** `validate-fixtures` is green — index valid, **0 invalid fixtures**, index paths consistent (29 fixtures). The SDK matrix jobs need this CI run to confirm.

## Asks
- **@flametrench-release** — this implements the *build-from-source-not-registry* pattern you and the PM flagged; please sanity-check the Java/Python approach.
- Holding merge until this run is green. If the SDK jobs surface a version skew I can't see from the spec repo, I'll coordinate on the SDK side before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)