### PR TITLE
conformance: extend capability enum for v0.4 primitives

### DIFF
--- a/conformance/fixture.schema.json
+++ b/conformance/fixture.schema.json
@@ -18,8 +18,8 @@
     },
     "capability": {
       "type": "string",
-      "enum": ["ids", "identity", "tenancy", "authorization"],
-      "description": "Which Flametrench v0.1 capability this fixture exercises."
+      "enum": ["ids", "identity", "tenancy", "authorization", "audit", "file-metadata", "flags", "notifications"],
+      "description": "Which Flametrench capability this fixture exercises."
     },
     "operation": {
       "type": "string",

--- a/conformance/index.schema.json
+++ b/conformance/index.schema.json
@@ -32,7 +32,7 @@
         },
         "capability": {
           "type": "string",
-          "enum": ["ids", "identity", "tenancy", "authorization"]
+          "enum": ["ids", "identity", "tenancy", "authorization", "audit", "file-metadata", "flags", "notifications"]
         },
         "operation": {
           "type": "string",


### PR DESCRIPTION
Applies QA & Conformance's suite-owner decisions to unblock v0.4 conformance fixtures (the gating prerequisite SiteSource is holding their first batch on).

**Change:** add the four v0.4 capability strings to **both** `capability` enums:
```json
["ids", "identity", "tenancy", "authorization", "audit", "file-metadata", "flags", "notifications"]
```
- `conformance/fixture.schema.json` → `properties.capability.enum` (+ drop `v0.1` from the description)
- `conformance/index.schema.json` → `$defs.FixtureEntry.properties.capability.enum`

Full-word convention (`authorization` not `authz`), matching ADR names 0019–0022.

**No assertion-shape changes** (per your Decisions 2/3): flag bucket vectors use `input`+`expected.result`; audit event-shape vectors use `expected.result` with per-fixture subset-match semantics. **`runnable_today` already exists** in the index schema (Decision 4) — no change needed.

**Verified locally:** both schemas valid JSON; existing fixtures still validate (0 invalid); index + `validate-conformance-index.mjs` green (29 fixtures consistent).

**@flametrench-qa-conformance** — yours to review against the decisions before merge, per your note. Once it's on main, SiteSource's flag-vector batch will validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)