### PR TITLE
fix(conformance): bump index spec_version to 0.4.0 — unbreak main

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./index.schema.json",
-  "spec_version": "0.3.0",
-  "description": "Flametrench conformance fixture manifest. Indexed at the current development spec version (0.3.0). Individual fixtures declare the spec_version they were introduced under; v0.1, v0.2, and v0.3 fixtures coexist in the same index. Harnesses auto-discover fixture files from this manifest.",
+  "spec_version": "0.4.0",
+  "description": "Flametrench conformance fixture manifest. Indexed at the current development spec version (0.4.0). Individual fixtures declare the spec_version they were introduced under; v0.1, v0.2, v0.3, and v0.4 fixtures coexist in the same index. Harnesses auto-discover fixture files from this manifest.",
   "fixtures": [
     {
       "path": "fixtures/ids/encode.json",


### PR DESCRIPTION
## Trunk hotfix

`spec` main is **red** (Conformance, job *Validate index.json fixture paths exist and match their metadata*):

```
fixtures/audit/write-event-shape.json: fixture spec_version=0.4.0 exceeds index spec_version=0.3.0
```

PR #41 merged the first **v0.4** fixture (audit `write-event-shape.json`) while `index.json` was still `0.3.0`. The validator enforces every fixture's `spec_version` ≤ the index's. Corpus now spans v0.4 → index must declare `0.4.0`.

## Fix
One-line bump: index `spec_version` `0.3.0`→`0.4.0` (+ description). v0.1–v0.4 fixtures coexist; audit stays `runnable_today:false`; no harness/behavior change.

## Verified green locally (exact CI commands)
- `ajv --spec=draft2020` index.json → valid
- `ajv --spec=draft2020` all 32 fixtures → valid
- `validate-conformance-index.mjs` → ✅ 32 declared, all consistent

Fix-forward per red-trunk protocol; PM authorized push-to-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)