### PR TITLE
conformance: flip structural-format-only to runnable_today: true (five-family PAT parity gate)

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -176,7 +176,7 @@
       "capability": "identity",
       "operation": "verify_pat_token",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/identity/pat/bearer-prefix-routing.json",


### PR DESCRIPTION
## Summary

- Flips `conformance/index.json` entry for `fixtures/identity/pat/structural-format-only.json` from `runnable_today: false` to `runnable_today: true`
- Unblocked by PHP v0.3.1 (`740476e`) merging to main (`5d3e3e8`) — all five families are now Go-normative on the PAT structural validator (pure wire-format, no 256-char length cap)
- Rebased onto `5c052b8` (Spec PR #45 — `spec_version` 0.4.0 bump)

## Evidence — five-family matrix verified

| Family | SHA | Structural validator | Verified |
|--------|-----|---------------------|----------|
| Java | `e8effbc` | `ConformanceTest.patStructuralFormatOnlyConformance()` — loads fixture directly; 86/86 ✓ | ✓ this session |
| PHP | `740476e` (v0.3.1) | `Pat::isStructurallyValid` — pure regex, no 256-cap; 257-char→`true` in `PatTest.php` | ✓ prior session |
| Node | `2615bdf` (v0.3.1) | `isStructurallyValidPatToken` — pure regex, no length cap | ✓ prior session |
| Python | `06c22d1` (v0.3.1) | `is_structurally_valid_pat_token` — pure regex, no length cap | ✓ prior session |
| Go | Go-normative reference | Original Go behavior (basis for the ruling) | ✓ normative |

## What this enables

This is the **PAT structural parity stamp** — the five-family convergence fixture is now live in the CI matrix. Any future family that enforces the 256-char cap inside `isStructurallyValid` will correctly fail this MUST-level fixture rather than silently diverging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)