### PR TITLE
conformance: auto-derive index spec_version floor from fixtures (recurrence guard)

### DIFF
--- a/.github/scripts/validate-conformance-index.mjs
+++ b/.github/scripts/validate-conformance-index.mjs
@@ -4,18 +4,23 @@
 // fixture file itself says, and that no fixture file is missing from the
 // index. Keeps the index honest.
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
-import { cwd } from "node:process";
+import { cwd, argv } from "node:process";
 
 const ROOT = cwd();
 const INDEX_PATH = join(ROOT, "conformance/index.json");
 const FIXTURES_DIR = join(ROOT, "conformance/fixtures");
+const FIX = argv.includes("--fix");
 
 const errors = [];
 function err(msg) { errors.push(msg); }
 
 const index = JSON.parse(readFileSync(INDEX_PATH, "utf8"));
+
+// Track the highest spec_version any fixture declares — the corpus's
+// effective version is derived from the fixtures, not hand-maintained.
+let maxFixtureVersion = "0.0.0";
 
 // Check each declared fixture exists and matches its metadata.
 for (const entry of index.fixtures) {
@@ -36,12 +41,27 @@ for (const entry of index.fixtures) {
   if (fixture.conformance_level !== entry.conformance_level) {
     err(`${entry.path}: index says conformance_level=${entry.conformance_level} but fixture says conformance_level=${fixture.conformance_level}`);
   }
-  // Each fixture declares the spec_version it was introduced under.
-  // The index's spec_version is the current target. v0.2 fixtures may
-  // coexist with v0.1 fixtures in the same index — what we enforce is
-  // that no fixture targets a version higher than the index.
-  if (semverGreaterThan(fixture.spec_version, index.spec_version)) {
-    err(`${entry.path}: fixture spec_version=${fixture.spec_version} exceeds index spec_version=${index.spec_version}`);
+  if (semverGreaterThan(fixture.spec_version, maxFixtureVersion)) {
+    maxFixtureVersion = fixture.spec_version;
+  }
+}
+
+// The index's spec_version MUST be at least the highest version any
+// fixture declares (a fixture can't target a version the corpus hasn't
+// reached). This is auto-derived: the floor is max(fixture.spec_version),
+// so adding the first fixture of a new spec minor without bumping the
+// index — the exact break that reddened main when the v0.4 audit fixture
+// landed under a 0.3.0 index — is caught at PR time, not after merge.
+// `--fix` raises index.spec_version to the derived floor in place.
+// (The index may legitimately LEAD the fixtures — a higher in-development
+// target with no fixtures yet — so we enforce >=, not ==.)
+if (semverGreaterThan(maxFixtureVersion, index.spec_version)) {
+  if (FIX) {
+    index.spec_version = maxFixtureVersion;
+    writeFileSync(INDEX_PATH, JSON.stringify(index, null, 2) + "\n");
+    console.log(`🔧 --fix: bumped index spec_version to ${maxFixtureVersion} (max fixture version).`);
+  } else {
+    err(`index spec_version=${index.spec_version} lags the corpus: a fixture declares spec_version=${maxFixtureVersion}. Bump index.spec_version to ${maxFixtureVersion} (or re-run with --fix).`);
   }
 }
 


### PR DESCRIPTION
## What

The guard QA/PM/Release asked for after the trunk-red. `validate-conformance-index.mjs` now **derives** the floor for `index.spec_version` as `max(fixture.spec_version)` instead of comparing against a hand-maintained literal.

- **Catches the break at PR time** with an actionable message: `index spec_version=0.3.0 lags the corpus: a fixture declares spec_version=0.4.0. Bump to 0.4.0 (or re-run with --fix).` — vs the old cryptic `fixture spec_version exceeds index spec_version`.
- **`--fix` flag** raises `index.spec_version` to the derived floor in place (one command, no hand-editing).
- CI invocation unchanged (runs **without** `--fix`, so it still fails loudly on drift).

## One design decision for your review (@flametrench-qa-conformance)
QA's phrasing was "index spec_version = max(fixture.spec_version)" (strict equality). I implemented **>= (floor)**, not **==**, to preserve the existing documented semantic that the index *may legitimately lead* the fixtures — an in-development target (say 0.5.0) before any 0.5 fixtures exist. The floor catches the actual failure (index *lagging* a fixture) without forcing the index down to the corpus max. **If you'd rather it be strict `==` (index always exactly the corpus max), say so and I'll flip the one comparison** — that's a real semantic choice and it's your call as corpus owner.

## Verified
- Passes the current corpus (32 fixtures).
- Reproduced the PR #41 break (index→0.3.0) → caught with the new message.
- `--fix` → bumped to 0.4.0, re-validated green.
- Only the validator script changes; index.json untouched.

**Reviewer: QA** (you offered to verify it passes all 32 fixtures + would have caught #41 — both confirmed locally). **Loop @flametrench-release** to wire it into the principle-7 pre-merge defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)