### PR TITLE
ci(conformance): pin Java-leg ids-java dep to v0.3.0 (unbreak sdk-java)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -248,15 +248,19 @@ jobs:
           path: sdk
 
       - name: Checkout flametrench/ids-java
-        # Build the ids dep from ids-java's default branch — version-coordinated
-        # with the SDK under test — instead of a pinned (stale) tag. The SDK
-        # poms depend on dev.flametrench:ids at the current development version;
-        # resolving it from Maven Central fails because we have not published
-        # there. CI must not depend on an unpublished registry.
+        # Build the ids dep from source (Maven Central is unpublished, so CI must
+        # not resolve it there). We pin to the release TAG matching the ids
+        # version the SDKs-under-test require (`v0.3.0`) rather than ids-java's
+        # default branch: ids-java main currently lags its tag (pom still 0.2.0),
+        # so building from main produces ids:0.2.0 and the SDK poms' ids:0.3.0
+        # dependency resolves to nothing. Matches the Java repos' own ci.yml.
+        # Bump this ref in lockstep when the SDKs move to a new required ids
+        # version (root fix: ids-java main pom bumped to match its tag).
         if: matrix.sdk != 'ids-java'
         uses: actions/checkout@v4
         with:
           repository: flametrench/ids-java
+          ref: v0.3.0
           path: _vendored/ids-java
 
       - name: Overlay live spec fixtures


### PR DESCRIPTION
## Trunk/CI hotfix

The `sdk-java` conformance leg can't build — failing every open v0.4 PR (and main):

```
Could not find artifact dev.flametrench:ids:jar:0.3.0 in central
```

**Root cause:** the leg vendors `ids-java`'s **default branch** (pom still `0.2.0`, lagging its v0.3.0 tag) while the SDK poms pin `ids:0.3.0` exactly → `mvn install` makes `0.2.0`, the dep resolves to nothing, falls through to blocked Maven Central. (Python survives the same shape via version ranges; Java uses exact pins.)

## Fix (PM's #2 — fast unblock)
Pin the vendored ids-java checkout to **`ref: v0.3.0`** (the version the SDKs require), matching the Java repos' own ci.yml. Still builds from source — no Maven Central dependency. Root fix (ids-java main pom → 0.3.0) routed to Java; this ref bumps in lockstep with the SDKs' required ids version.

Validated: YAML parses; `ref` correctly placed between `repository` and `path`. Unblocks all 6 of my open v0.4 PRs' Java leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)