### PR TITLE
ADR 0022: pin notify error taxonomy (InvalidFormatError + PreconditionError)

### DIFF
--- a/decisions/0022-notify-primitive.md
+++ b/decisions/0022-notify-primitive.md
@@ -100,6 +100,21 @@ A notification is scoped to one `org` and addressed to one recipient. The `listN
 - `subject.id` follows the Flametrench-vs-adopter id split (decodable Flametrench ids; opaque adopter ids).
 - `data` is a JSON object ≤ 16 KB. The primitive stores and returns it; it does not interpret or render it.
 
+### Errors (normative)
+
+`createNotification` and the state-transition operations validate inputs and lifecycle. Violations raise the **uniform cross-capability taxonomy** (see [ADR 0019](./0019-audit-primitive.md) §Errors and the input-value-vs-state split): malformed input **values** raise `InvalidFormatError` with a `field` discriminator; **state-machine** violations raise `PreconditionError`. No notify-specific error classes.
+
+| Violation | Error |
+|---|---|
+| `type` outside `^[a-z0-9._-]{1,64}$` | `InvalidFormatError`, field `type` |
+| `data` not a JSON object, or > 16 KB | `InvalidFormatError`, field `data` |
+| `recipient_usr_id` not a valid `usr_<32hex>` | `InvalidFormatError`, field `recipient_usr_id` |
+| `scope` not a valid `org_<32hex>` | `InvalidFormatError`, field `scope` |
+| `subject` malformed (missing `kind`/`id`, or wrong shape) | `InvalidFormatError`, field `subject` |
+| A transition out of `dismissed` (terminal) — `markRead`/`markUnread`/`dismiss` on an already-dismissed notification | `PreconditionError` |
+
+**Recipient-scope / existence non-disclosure (NOT an input error).** Per §"Access — strictly recipient-scoped" and §"Tenancy non-inference", `get`/`markRead`/`markUnread`/`dismiss`/`countUnread`/`listNotifications` targeting a notification the caller does **not** own MUST be **indistinguishable from targeting a non-existent one**: both raise the **same** not-found error (e.g. `NotFoundError`), with no presence/count/error-code/timing differential that could reveal a foreign notification's existence. Implementations MUST NOT raise a distinct "forbidden/denied" error for the cross-recipient case — that differential would itself be the existence oracle the non-inference rule forbids. (This is the recipient-scoped instance of the [ADR 0019](./0019-audit-primitive.md) cross-scope non-disclosure discipline.)
+
 ## Consequences
 
 **Positive:**


### PR DESCRIPTION
## What

ADR 0022 named no error types — blocking SiteSource's notify **negative** vectors (parallel to audit #43 / file #51). Adds an **Errors (normative)** subsection reusing the uniform cross-capability taxonomy:

- **`InvalidFormatError` (field-scoped):** `type` (regex), `data` (object / ≤16KB), `recipient_usr_id`, `scope`, `subject` shape.
- **`PreconditionError`:** the one state-machine violation — a transition **out of terminal `dismissed`** (`markRead`/`markUnread`/`dismiss` on an already-dismissed notification).
- **Recipient-scope non-disclosure (pinned, not an input error):** cross-recipient and non-existent targets MUST raise the **same** not-found error — no forbidden/denied differential — the recipient-scoped instance of ADR 0019's existence-non-inference rule. This is the load-bearing security bit for notify's negative vectors.

Consistent with #43 (0019) and #51 (0020). 0022 is **Proposed** — refine in place. Reviewer: QA / SiteSource. Unblocks the PR #52 negative follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)