### PR TITLE
conformance: flip list-orgs to runnable_today: true (five-family parity)

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -74,7 +74,7 @@
       "capability": "tenancy",
       "operation": "list_orgs",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/tenancy/change-role.json",


### PR DESCRIPTION
## What

Flips `tenancy/list-orgs.json` to `runnable_today: true` — the five-family `listOrgs` (ADR 0025) parity gate. All five SDKs have landed it on main + cleared QA:

| SDK | SHA |
|---|---|
| Node | `ab637f9` |
| PHP | `55727d3` |
| Go | `6c48083` |
| Python | `afe1081` |
| Java | `tenancy-java` main `feff205` (listOrgs `9047d9f`/`414cbe0`) |

Verified Java independently on main before flipping (its source has `listOrgs` in InMem/Postgres stores + ConformanceTest) so the enforcing fixture doesn't redden Java's leg. Same all-five-gate pattern as the PAT structural-format flip (#47).

Only `list-orgs` flips; `audit/write-event-shape.json` stays `runnable_today:false` (no SDK yet). Validated: index 33 consistent, ajv-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)