### PR TITLE
conformance: flip audit to runnable_today: true (audit parity 5/5)

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -203,7 +203,7 @@
       "capability": "audit",
       "operation": "write",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/notifications/lifecycle-shape.json",


### PR DESCRIPTION
Flips `audit/write-event-shape.json` → enforcing. All five SDKs have the ADR 0019 audit layer on main + QA-passed (Node `8e44988` · PHP main · Java main · Python `cb09bd6` · Go `67b0480`; Release-confirmed, spot-verified Go+Node `packages/audit` on main). First v0.4 primitive locked in conformance. Only audit flips; notify/flags/file stay `false`. Validated: index 36 consistent.