### PR TITLE
conformance(notify positives): Option-2 recipient signature for lifecycle-shape.json

### DIFF
--- a/conformance/fixtures/notifications/lifecycle-shape.json
+++ b/conformance/fixtures/notifications/lifecycle-shape.json
@@ -5,12 +5,14 @@
   "operation": "create_notification",
   "conformance_level": "MUST",
   "spec_section": "decisions/0022-notify-primitive.md#lifecycle-normative",
-  "description": "Notification create/get round-trips and the full read-state lifecycle machine (ADR 0022): created `unread`, `unread ⇄ read` toggles both directions, `unread → dismissed` and `read → dismissed`. These are positive structural-invariant vectors: each creates a notification then transitions and re-reads it, asserting the stored shape and `state`. The `data` object is stored and returned VERBATIM (the primitive is a record/event store, NOT a delivery engine — it never renders or templates `data`); `type` and adopter `subject.id` are opaque. Matching for `get` results is SUPERSET (result ⊇ expected). `state_changed_at` is asserted by neither value nor monotonicity here — like audit `recorded_at`, the per-transition update is an SDK-unit-test property, not superset-expressible. FOLLOW-ONS (own vectors): the terminal-`dismissed` rejection (dismissed accepts no further transition) and recipient-scoping/non-inference (access strictly bound to `recipient_usr_id`) — the former needs the invalid-transition error name (house-uniform `PreconditionError`, pending confirmation it extends to notify), the latter couples to authenticated-caller state. `runnable_today:false` until an SDK implements the notifications layer.",
+  "description": "Notification create/get round-trips and the full read-state lifecycle machine (ADR 0022): created `unread`, `unread \u21c4 read` toggles both directions, `unread \u2192 dismissed` and `read \u2192 dismissed`. These are positive structural-invariant vectors: each creates a notification then transitions and re-reads it, asserting the stored shape and `state`. The `data` object is stored and returned VERBATIM (the primitive is a record/event store, NOT a delivery engine \u2014 it never renders or templates `data`); `type` and adopter `subject.id` are opaque. Matching for `get` results is SUPERSET (result \u2287 expected). `state_changed_at` is asserted by neither value nor monotonicity here \u2014 like audit `recorded_at`, the per-transition update is an SDK-unit-test property, not superset-expressible. FOLLOW-ONS (own vectors): the terminal-`dismissed` rejection (dismissed accepts no further transition) and recipient-scoping/non-inference (access strictly bound to `recipient_usr_id`) \u2014 the former needs the invalid-transition error name (house-uniform `PreconditionError`, pending confirmation it extends to notify), the latter couples to authenticated-caller state. `runnable_today:false` until an SDK implements the notifications layer. Per Option-2 (SDK-enforced recipient-scoping, ADR 0022), the per-notification ops (`get`/`markRead`/`markUnread`/`dismiss`) take the authenticated `recipient_usr_id` alongside `id`.",
   "tests": [
     {
       "id": "create.full_shape_round_trip_unread",
-      "description": "A notification is created `unread` (ADR 0022). create → get round-trips the full Notification shape: scope, recipient, opaque `type`, `subject` (adopter id, opaque/not decoded), and the structured `data` object stored verbatim. `data` is plain record content, not a template — the primitive returns it byte-for-byte.",
-      "users": ["recipient"],
+      "description": "A notification is created `unread` (ADR 0022). create \u2192 get round-trips the full Notification shape: scope, recipient, opaque `type`, `subject` (adopter id, opaque/not decoded), and the structured `data` object stored verbatim. `data` is plain record content, not a template \u2014 the primitive returns it byte-for-byte.",
+      "users": [
+        "recipient"
+      ],
       "steps": [
         {
           "op": "create_notification",
@@ -18,22 +20,39 @@
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "recipient_usr_id": "{recipient}",
             "type": "comment.mention",
-            "subject": { "kind": "doc", "id": "doc_2f9c1a00000000000000000000000001" },
-            "data": { "actor_name": "Alice", "snippet": "…@bob take a look" }
+            "subject": {
+              "kind": "doc",
+              "id": "doc_2f9c1a00000000000000000000000001"
+            },
+            "data": {
+              "actor_name": "Alice",
+              "snippet": "\u2026@bob take a look"
+            }
           },
-          "captures": { "not_id": "id" }
+          "captures": {
+            "not_id": "id"
+          }
         },
         {
           "op": "get_notification",
-          "input": { "id": "{not_id}" },
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          },
           "expected": {
             "result": {
               "id": "{not_id}",
               "scope": "org_0190f2a81b3c7abc8123000000000004",
               "recipient_usr_id": "{recipient}",
               "type": "comment.mention",
-              "subject": { "kind": "doc", "id": "doc_2f9c1a00000000000000000000000001" },
-              "data": { "actor_name": "Alice", "snippet": "…@bob take a look" },
+              "subject": {
+                "kind": "doc",
+                "id": "doc_2f9c1a00000000000000000000000001"
+              },
+              "data": {
+                "actor_name": "Alice",
+                "snippet": "\u2026@bob take a look"
+              },
               "state": "unread"
             }
           }
@@ -42,8 +61,10 @@
     },
     {
       "id": "mark_read_then_unread.toggles_both_directions",
-      "description": "`unread ⇄ read` toggles in BOTH directions (ADR 0022): `markRead` moves unread→read, `markUnread` moves read→unread (a user re-flagging an item as unread is a real pattern). Asserts state after each toggle.",
-      "users": ["recipient"],
+      "description": "`unread \u21c4 read` toggles in BOTH directions (ADR 0022): `markRead` moves unread\u2192read, `markUnread` moves read\u2192unread (a user re-flagging an item as unread is a real pattern). Asserts state after each toggle.",
+      "users": [
+        "recipient"
+      ],
       "steps": [
         {
           "op": "create_notification",
@@ -51,35 +72,64 @@
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "recipient_usr_id": "{recipient}",
             "type": "invite.received",
-            "subject": { "kind": "org", "id": "org_0190f2a81b3c7abc8123000000000004" },
+            "subject": {
+              "kind": "org",
+              "id": "org_0190f2a81b3c7abc8123000000000004"
+            },
             "data": {}
           },
-          "captures": { "not_id": "id" }
+          "captures": {
+            "not_id": "id"
+          }
         },
         {
           "op": "mark_read",
-          "input": { "id": "{not_id}" }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          }
         },
         {
           "op": "get_notification",
-          "input": { "id": "{not_id}" },
-          "expected": { "result": { "id": "{not_id}", "state": "read" } }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          },
+          "expected": {
+            "result": {
+              "id": "{not_id}",
+              "state": "read"
+            }
+          }
         },
         {
           "op": "mark_unread",
-          "input": { "id": "{not_id}" }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          }
         },
         {
           "op": "get_notification",
-          "input": { "id": "{not_id}" },
-          "expected": { "result": { "id": "{not_id}", "state": "unread" } }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          },
+          "expected": {
+            "result": {
+              "id": "{not_id}",
+              "state": "unread"
+            }
+          }
         }
       ]
     },
     {
       "id": "dismiss.from_unread",
-      "description": "`unread → dismissed` is a valid transition (ADR 0022: `read | unread → dismissed`). A user can dismiss a notification without first reading it. Asserts state:dismissed after dismiss directly from unread.",
-      "users": ["recipient"],
+      "description": "`unread \u2192 dismissed` is a valid transition (ADR 0022: `read | unread \u2192 dismissed`). A user can dismiss a notification without first reading it. Asserts state:dismissed after dismiss directly from unread.",
+      "users": [
+        "recipient"
+      ],
       "steps": [
         {
           "op": "create_notification",
@@ -87,26 +137,46 @@
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "recipient_usr_id": "{recipient}",
             "type": "job.finished",
-            "subject": { "kind": "job", "id": "export-job-9" },
-            "data": { "status": "complete" }
+            "subject": {
+              "kind": "job",
+              "id": "export-job-9"
+            },
+            "data": {
+              "status": "complete"
+            }
           },
-          "captures": { "not_id": "id" }
+          "captures": {
+            "not_id": "id"
+          }
         },
         {
           "op": "dismiss",
-          "input": { "id": "{not_id}" }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          }
         },
         {
           "op": "get_notification",
-          "input": { "id": "{not_id}" },
-          "expected": { "result": { "id": "{not_id}", "state": "dismissed" } }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          },
+          "expected": {
+            "result": {
+              "id": "{not_id}",
+              "state": "dismissed"
+            }
+          }
         }
       ]
     },
     {
       "id": "dismiss.from_read",
-      "description": "`read → dismissed` is a valid transition (ADR 0022). Asserts a notification marked read then dismissed reaches state:dismissed. (That `dismissed` is TERMINAL — accepts no further transition — is the negative vector, deferred pending the invalid-transition error name.)",
-      "users": ["recipient"],
+      "description": "`read \u2192 dismissed` is a valid transition (ADR 0022). Asserts a notification marked read then dismissed reaches state:dismissed. (That `dismissed` is TERMINAL \u2014 accepts no further transition \u2014 is the negative vector, deferred pending the invalid-transition error name.)",
+      "users": [
+        "recipient"
+      ],
       "steps": [
         {
           "op": "create_notification",
@@ -114,23 +184,44 @@
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "recipient_usr_id": "{recipient}",
             "type": "approval.requested",
-            "subject": { "kind": "doc", "id": "doc_2f9c1a00000000000000000000000002" },
-            "data": { "requester": "Carol" }
+            "subject": {
+              "kind": "doc",
+              "id": "doc_2f9c1a00000000000000000000000002"
+            },
+            "data": {
+              "requester": "Carol"
+            }
           },
-          "captures": { "not_id": "id" }
+          "captures": {
+            "not_id": "id"
+          }
         },
         {
           "op": "mark_read",
-          "input": { "id": "{not_id}" }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          }
         },
         {
           "op": "dismiss",
-          "input": { "id": "{not_id}" }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          }
         },
         {
           "op": "get_notification",
-          "input": { "id": "{not_id}" },
-          "expected": { "result": { "id": "{not_id}", "state": "dismissed" } }
+          "input": {
+            "recipient_usr_id": "{recipient}",
+            "id": "{not_id}"
+          },
+          "expected": {
+            "result": {
+              "id": "{not_id}",
+              "state": "dismissed"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Security ruled **Option-2 (SDK-enforced recipient-scoping)** — ADR 0022 update in #61. The per-notification ops now take the authenticated `recipient_usr_id`.

Updates the merged `lifecycle-shape.json` **positives** to match: every `get_notification`/`mark_read`/`mark_unread`/`dismiss` step now passes `recipient_usr_id: {recipient}` alongside `id` (10 steps). `runnable_today:false` unchanged; ajv-validated.

Part of the same Option-2 rework the SDK teams are doing. My negatives PR (#60) got the same signature update + the existence-before-state precedence case. The cross-recipient IDOR/count vector is FT Spec's sibling (recipient-scope.json, #61).

cc @ Flametrench Spec (ADR-0022 fidelity) + QA-Conformance (suite-fit). Should land with #61 + #60 before the notify flip.