### PR TITLE
conformance: pin v0.4 ids type-prefix registry (drift guard)

### DIFF
--- a/conformance/fixtures/ids/registered-prefixes.json
+++ b/conformance/fixtures/ids/registered-prefixes.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../fixture.schema.json",
+  "spec_version": "0.4.0",
+  "capability": "ids",
+  "operation": "type_of",
+  "conformance_level": "MUST",
+  "spec_section": "docs/ids.md#type-prefix-registry",
+  "description": "Pins the v0.4 type-prefix registry (`docs/ids.md`) cross-SDK so a silently-dropped prefix is a hard conformance failure, not a local green. `type_of` returns the prefix of a valid id; a prefix the SDK has NOT registered raises `InvalidTypeError` instead — so `type_of(aud_<uuid>) → 'aud'` fails on any SDK whose registry dropped `aud`. This is the durable guard for the drift Go PR #3 surfaced (file/flag/not dropped from the Go registry; Python/Java registries stopped at v0.2). `runnable_today:false` until all five ids SDKs have the v0.4 prefixes registered on main (Go/Python/Java restores in flight) — then flip to `true` and a re-drift becomes a cross-SDK red. (Making it runnable while 3/5 lag would redden main's ids legs and poison the vendor tree; it flips the moment the registries are restored, the per-primitive-gate pattern.)",
+  "tests": [
+    {
+      "id": "registered_prefixes.aud",
+      "description": "`aud` (audit event, v0.4 ADR 0019) is a registered prefix — type_of returns it, not InvalidTypeError.",
+      "input": { "id": "aud_0190f2a81b3c7abc8123456789abcdef" },
+      "expected": { "result": "aud" }
+    },
+    {
+      "id": "registered_prefixes.file",
+      "description": "`file` (file metadata, v0.4 ADR 0020) is a registered prefix.",
+      "input": { "id": "file_0190f2a81b3c7abc8123456789abcdef" },
+      "expected": { "result": "file" }
+    },
+    {
+      "id": "registered_prefixes.flag",
+      "description": "`flag` (feature flag, v0.4 ADR 0021) is a registered prefix.",
+      "input": { "id": "flag_0190f2a81b3c7abc8123456789abcdef" },
+      "expected": { "result": "flag" }
+    },
+    {
+      "id": "registered_prefixes.not",
+      "description": "`not` (notification, v0.4 ADR 0022) is a registered prefix.",
+      "input": { "id": "not_0190f2a81b3c7abc8123456789abcdef" },
+      "expected": { "result": "not" }
+    }
+  ]
+}

--- a/conformance/index.json
+++ b/conformance/index.json
@@ -34,6 +34,13 @@
       "conformance_level": "MUST"
     },
     {
+      "path": "fixtures/ids/registered-prefixes.json",
+      "capability": "ids",
+      "operation": "type_of",
+      "conformance_level": "MUST",
+      "runnable_today": false
+    },
+    {
       "path": "fixtures/identity/argon2id.json",
       "capability": "identity",
       "operation": "verify_password",


### PR DESCRIPTION
Adds `ids/registered-prefixes.json` pinning `aud`/`file`/`flag`/`not` cross-SDK so a dropped prefix is a hard conformance failure (the drift Go PR #3 surfaced; Python/Java registries stopped at v0.2). `type_of(aud_<uuid>)` → `'aud'` fails on any SDK that dropped it.

**`runnable_today:false`** — 3/5 SDKs currently lack the v0.4 prefixes (Go/Python/Java restores in flight per PM); making it runnable now would redden main's ids legs and poison the vendor tree. **Flip to `true` once all five registries are restored on main** (I'll do it on PM's all-restored signal) → re-drift becomes a cross-SDK red. `runnable_today` is per-file, so a sibling fixture (not extending the runnable `type-of.json`) is how the flag is controlled separately.

Validated: index 38 consistent, fixture ajv-clean. Reviewer: QA.