### PR TITLE
ADR 0021: pin dup-key error taxonomy (PreconditionError) + conformance vector

### DIFF
--- a/conformance/fixtures/flags/duplicate-key.json
+++ b/conformance/fixtures/flags/duplicate-key.json
@@ -5,7 +5,7 @@
   "operation": "create_flag",
   "conformance_level": "MUST",
   "spec_section": "decisions/0021-flags-primitive.md#errors-normative",
-  "description": "Duplicate `(scope, key)` → `PreconditionError` (ADR 0021 §Errors / §Constraints within-scope key uniqueness). A second `createFlag` with the same `scope`+`key` MUST raise `PreconditionError` — NOT a primitive-specific class. This pins the cross-SDK convergence away from the outliers QA found (Python `ConflictError`, Go `ErrKeyConflict`); the canonical `PreconditionError` maps to each idiom (typed class in PHP/Java/Node/Python; a sentinel matchable via `IsPrecondition()` in Go). `runnable_today:false` until flags is implemented across all five SDKs and converged on the error class.",
+  "description": "Duplicate `(scope, key)` \u2192 `PreconditionError` (ADR 0021 \u00a7Errors / \u00a7Constraints within-scope key uniqueness). A second `createFlag` with the same `scope`+`key` MUST raise `PreconditionError` \u2014 NOT a primitive-specific class. This pins the cross-SDK convergence away from the outliers QA found (Python `ConflictError`, Go `ErrKeyConflict`); the canonical `PreconditionError` maps to each idiom (typed class in PHP/Java/Node/Python; a sentinel matchable via `IsPrecondition()` in Go). `runnable_today:false` until flags is implemented across all five SDKs and converged on the error class.",
   "tests": [
     {
       "id": "create_flag.duplicate_scope_key_is_precondition",
@@ -16,7 +16,9 @@
           "input": {
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "key": "checkout.new-flow",
-            "basis_points": 0
+            "enabled": true,
+            "default_variant": false,
+            "rules": []
           }
         },
         {
@@ -24,9 +26,13 @@
           "input": {
             "scope": "org_0190f2a81b3c7abc8123000000000004",
             "key": "checkout.new-flow",
-            "basis_points": 0
+            "enabled": true,
+            "default_variant": false,
+            "rules": []
           },
-          "expected": { "error": "PreconditionError" }
+          "expected": {
+            "error": "PreconditionError"
+          }
         }
       ]
     }

--- a/conformance/fixtures/flags/duplicate-key.json
+++ b/conformance/fixtures/flags/duplicate-key.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../fixture.schema.json",
+  "spec_version": "0.4.0",
+  "capability": "flags",
+  "operation": "create_flag",
+  "conformance_level": "MUST",
+  "spec_section": "decisions/0021-flags-primitive.md#errors-normative",
+  "description": "Duplicate `(scope, key)` → `PreconditionError` (ADR 0021 §Errors / §Constraints within-scope key uniqueness). A second `createFlag` with the same `scope`+`key` MUST raise `PreconditionError` — NOT a primitive-specific class. This pins the cross-SDK convergence away from the outliers QA found (Python `ConflictError`, Go `ErrKeyConflict`); the canonical `PreconditionError` maps to each idiom (typed class in PHP/Java/Node/Python; a sentinel matchable via `IsPrecondition()` in Go). `runnable_today:false` until flags is implemented across all five SDKs and converged on the error class.",
+  "tests": [
+    {
+      "id": "create_flag.duplicate_scope_key_is_precondition",
+      "description": "Two `createFlag` calls with the same `(scope, key)`: the first succeeds; the second MUST raise `PreconditionError` (the key already exists in the scope). It MUST NOT be a novel conflict class.",
+      "steps": [
+        {
+          "op": "create_flag",
+          "input": {
+            "scope": "org_0190f2a81b3c7abc8123000000000004",
+            "key": "checkout.new-flow",
+            "basis_points": 0
+          }
+        },
+        {
+          "op": "create_flag",
+          "input": {
+            "scope": "org_0190f2a81b3c7abc8123000000000004",
+            "key": "checkout.new-flow",
+            "basis_points": 0
+          },
+          "expected": { "error": "PreconditionError" }
+        }
+      ]
+    }
+  ]
+}

--- a/conformance/index.json
+++ b/conformance/index.json
@@ -234,6 +234,13 @@
       "runnable_today": false
     },
     {
+      "path": "fixtures/flags/duplicate-key.json",
+      "capability": "flags",
+      "operation": "create_flag",
+      "conformance_level": "MUST",
+      "runnable_today": false
+    },
+    {
       "path": "fixtures/file-metadata/lifecycle-shape.json",
       "capability": "file-metadata",
       "operation": "create_file_metadata",

--- a/decisions/0021-flags-primitive.md
+++ b/decisions/0021-flags-primitive.md
@@ -127,6 +127,22 @@ A `flag` is scoped to one `org`. Cross-scope access is impossible through the pr
 - `basis_points` is an integer in `[0, 10000]`.
 - A rule's `relation` matches the authz relation grammar (`^[a-z_]{2,32}$`, ADR 0001); `object.type`/`object.id` follow the authz object rules (Flametrench-entity ids decodable, adopter ids opaque).
 
+### Errors (normative)
+
+`createFlag`/`updateFlag` validate inputs and the within-scope uniqueness constraint. Violations raise the **uniform cross-capability taxonomy** (see [ADR 0019](./0019-audit-primitive.md) §Errors and the input-value-vs-state split): malformed input **values** raise `InvalidFormatError` with a `field` discriminator; violations of a **state/constraint** (the `(scope, key)` uniqueness) raise `PreconditionError`. No flag-specific error classes.
+
+| Violation | Error |
+|---|---|
+| `createFlag` with a `(scope, key)` that already exists in the scope (the §Constraints uniqueness) | `PreconditionError` |
+| `key` outside `^[a-z0-9._-]{1,128}$` | `InvalidFormatError`, field `key` |
+| `basis_points` not an integer in `[0, 10000]` | `InvalidFormatError`, field `basis_points` |
+| a rule's `relation` / `object` outside the authz grammar | `InvalidFormatError`, field `relation` / `object` |
+| `scope` not a valid `org_<32hex>` | `InvalidFormatError`, field `scope` |
+
+**Duplicate `(scope, key)` is `PreconditionError`, not a new class.** It is the flag-key uniqueness constraint failing — a state/constraint violation, the same class ADR 0019/0020/0022/0024 use. A novel `ConflictError`/`ErrKeyConflict` would contradict the "no primitive-specific error classes" rule and diverge the cross-SDK contract (it already did: PHP/Java/Node chose `PreconditionError`; Python `ConflictError` and Go `ErrKeyConflict` are the outliers and converge to `PreconditionError`).
+
+**Cross-language idiom mapping.** The canonical error name (`PreconditionError`, `InvalidFormatError`) maps to each binding's idiom: a typed exception/class in PHP/Java/Node/Python (`PreconditionError`/`PreconditionException`), and in Go an **idiomatic typed sentinel** matchable via `errors.Is` and surfaced through a predicate (`IsPrecondition(err)` / `IsInvalidFormat(err)`) — Go is not required to mint an exception *class*, but its dup-key sentinel MUST satisfy `IsPrecondition`, exactly as it already exposes `IsInvalidFormat`. Conformance asserts the canonical name; each SDK's harness maps it to its idiom.
+
 ## Consequences
 
 **Positive:**


### PR DESCRIPTION
## Ruling (unblocks the flags cohort)

Duplicate `(scope, key)` → **`PreconditionError`** — the within-scope key-uniqueness constraint failing is a state/constraint violation, the uniform cross-capability taxonomy (ADR 0019/0020/0022/0024). PHP/Java/Node already chose it; **Python (`ConflictError`) and Go (`ErrKeyConflict`) are the outliers → converge to `PreconditionError`.**

Adds the missing **ADR 0021 §Errors** section (the gap that let this drift) + a **cross-language idiom note**: canonical names map per binding — typed class in PHP/Java/Node/Python; in Go an `errors.Is` sentinel surfaced via `IsPrecondition()` (Go needn't mint a *class*, but its dup-key sentinel MUST satisfy `IsPrecondition`, exactly as it exposes `IsInvalidFormat`).

New fixture `flags/duplicate-key.json` (`runnable_today:false`): `createFlag` twice same `(scope,key)` → `PreconditionError`. Flips at flags 5/5.

**Reviewer: QA** (same review as #43/#54 + the dup-key vector suite-fit — confirm the `createFlag` input shape if it needs more than scope/key/basis_points). Validated: index 39 consistent, fixture ajv-clean. Python renames `ConflictError`; Go names/exposes the precondition sentinel (PM relaying).