### PR TITLE
conformance: flip ids/registered-prefixes.json to runnable_today: true

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -38,7 +38,7 @@
       "capability": "ids",
       "operation": "type_of",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/identity/argon2id.json",


### PR DESCRIPTION
All five ids registries restored (Go `d1c9be5` PR#3, Java `29bd0b7`, Python `c71980c`, Node, PHP — independently verified `aud/file/flag/not` in each). Flips the prefix drift guard to enforcing; it's under `ids/` (overlaid into all 5 legs) so re-drift is a hard cross-SDK red. Clears the last ids@0.4.0 gate. Validated: index 38 consistent.