### PR TITLE
conformance: flip flags parity gates to runnable_today: true (5/5)

### DIFF
--- a/conformance/index.json
+++ b/conformance/index.json
@@ -231,14 +231,14 @@
       "capability": "flags",
       "operation": "assign_bucket",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/flags/duplicate-key.json",
       "capability": "flags",
       "operation": "create_flag",
       "conformance_level": "MUST",
-      "runnable_today": false
+      "runnable_today": true
     },
     {
       "path": "fixtures/file-metadata/lifecycle-shape.json",


### PR DESCRIPTION
Flips both flags conformance gates to `runnable_today: true` now that flags is **5/5** across both dimensions (per PM `flags-5of5` + QA's cross-SDK sign-off):

- **bucket** — PHP/Java/Node/Go/Python all pass `assign-bucket.json` (7/7, byte-identical)
- **dup-key error class** — all 5 converge on `PreconditionError` / `IsPrecondition` (Python `a23b95f` + Go `d1c9be5` were the last two; QA lifted both conditionals)

Completes the flags parity stamp (bucket + error-class).

### Scope (honest)
flags is **not yet in the `conformance.yml` overlay** (the matrix overlays only `ids/identity/tenancy/authorization`), so this flip is **SDK-suite-enforced, not matrix-live** — exactly the audit-flip scoping. It becomes a cross-SDK matrix red once the P3 overlay adds flags. Until then, a re-drift on any of the 5 surfaces as a local conformance red the moment that SDK re-vendors this index.

### Review basis
The substantive review is QA's 5/5 cross-SDK verification (both dimensions). This PR is the mechanical gate flip on top of that sign-off. Index validator green locally (40 fixtures, consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)